### PR TITLE
Some fixes and new classes/methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 *.rbc
 pkg
+.rvmrc

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.rbc
 pkg
 .rvmrc
+coverage/*

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'rake/gempackagetask'
 require 'rake/rdoctask'
+require 'rake/testtask'
 
 Rake::RDocTask.new do |t|
   t.rdoc_files   = Dir['lib/**/*.rb']
@@ -28,3 +29,10 @@ end
 
 Rake::GemPackageTask.new(spec) do |t|
 end
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/**/*_test.rb"]
+end
+
+task :default => [:test]

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'rake/gempackagetask'
 require 'rake/rdoctask'
 require 'rake/testtask'
+require 'rcov/rcovtask'
 
 Rake::RDocTask.new do |t|
   t.rdoc_files   = Dir['lib/**/*.rb']
@@ -28,6 +29,12 @@ def spec
 end
 
 Rake::GemPackageTask.new(spec) do |t|
+end
+
+Rcov::RcovTask.new do |t|
+  t.libs << "test"
+  t.rcov_opts << "--exclude gems"
+  t.test_files = FileList["test/**/*_test.rb"]
 end
 
 Rake::TestTask.new do |t|

--- a/lib/llvm.rb
+++ b/lib/llvm.rb
@@ -6,9 +6,9 @@ module LLVM
 
     # load required libraries
     begin
-      ffi_lib 'LLVM-2.8'
+      ffi_lib ['LLVM-2.8', 'libLLVM-2.8']
     rescue LoadError
-      ffi_lib 'LLVM-2.7'
+      ffi_lib ['LLVM-2.7', 'libLLVM-2.7']
     end
   end
   

--- a/lib/llvm.rb
+++ b/lib/llvm.rb
@@ -3,8 +3,13 @@ require 'ffi'
 module LLVM
   module C
     extend ::FFI::Library
+
     # load required libraries
-    ffi_lib 'LLVM-2.7'
+    begin
+      ffi_lib 'LLVM-2.8'
+    rescue LoadError
+      ffi_lib 'LLVM-2.7'
+    end
   end
   
   NATIVE_INT_SIZE = case FFI::Platform::ARCH

--- a/lib/llvm/analysis.rb
+++ b/lib/llvm/analysis.rb
@@ -35,12 +35,8 @@ module LLVM
   end
   
   class Function
-    def verify(action = :abort)
-      str = FFI::MemoryPointer.new(FFI.type_size(:pointer))
-      case status = C.LLVMVerifyFunction(self, action, str)
-        when 1 then str.read_string
-        else nil
-      end
+    def verify(action = :abort_process)
+      !!C.LLVMVerifyFunction(self, action)
     end
   end
 end

--- a/lib/llvm/analysis.rb
+++ b/lib/llvm/analysis.rb
@@ -36,7 +36,7 @@ module LLVM
   
   class Function
     def verify(action = :abort_process)
-      !!C.LLVMVerifyFunction(self, action)
+      C.LLVMVerifyFunction(self, action) != 0
     end
   end
 end

--- a/lib/llvm/core.rb
+++ b/lib/llvm/core.rb
@@ -459,7 +459,7 @@ module LLVM
     attach_function :LLVMBuildSExt, [:pointer, :pointer, :pointer, :string], :pointer
     attach_function :LLVMBuildFPToUI, [:pointer, :pointer, :pointer, :string], :pointer
     attach_function :LLVMBuildFPToSI, [:pointer, :pointer, :pointer, :string], :pointer
-    attach_function :LLVMBuildUIToFP, [:pointer, :pointer, :string], :pointer
+    attach_function :LLVMBuildUIToFP, [:pointer, :pointer, :pointer, :string], :pointer
     attach_function :LLVMBuildSIToFP, [:pointer, :pointer, :pointer, :string], :pointer
     attach_function :LLVMBuildFPTrunc, [:pointer, :pointer, :pointer, :string], :pointer
     attach_function :LLVMBuildFPExt, [:pointer, :pointer, :pointer, :string], :pointer

--- a/lib/llvm/core.rb
+++ b/lib/llvm/core.rb
@@ -24,7 +24,76 @@ module LLVM
       :no_implicit_float, 1 << 23,
       :naked,             1 << 24
     ]
-    
+
+    enum :opcode, [
+      # Terminator Instructions
+      :ret,             1,
+      :br,              2,
+      :switch,          3,
+      :indirectbr,      4,
+      :invoke,          5,
+      :unwind,          6,
+      :unreachable,     7,
+
+      # Standard Binary Operators
+      :add,             8,
+      :fadd,            9,
+      :sub,             10,
+      :fsub,            11,
+      :mul,             12,
+      :fmul,            13,
+      :udiv,            14,
+      :sdiv,            15,
+      :fdiv,            16,
+      :urem,            17,
+      :srem,            18,
+      :frem,            19,
+
+      # Logical Operators
+      :shl,             20,
+      :lshr,            21,
+      :ashr,            22,
+      :and,             23,
+      :or,              24,
+      :xor,             25,
+
+      # Memory Operators
+      :alloca,          26,
+      :load,            27,
+      :store,           28,
+      :getelementptr,   29,
+
+      # Cast Operators
+      :trunc,           30,
+      :zext,            31,
+      :sext,            32,
+      :fptoui,          33,
+      :fptosi,          34,
+      :uitofp,          35,
+      :sitofp,          36,
+      :fptrunc,         37,
+      :fpext,           38,
+      :ptrtoint,        39,
+      :inttoptr,        40,
+      :bitcast,         41,
+
+      # Other Operators
+      :icmp,            42,
+      :fcmp,            43,
+      :phi,             44,
+      :call,            45,
+      :select,          46,
+
+      # UserOp1
+      # UserOp2
+      :vaarg,           49,
+      :extractelement,  50,
+      :insertelement,   51,
+      :shufflevector,   52,
+      :extractvalue,    53,
+      :insertvalue,     54,
+    ]
+
     enum :type_kind, [
       :void,
       :float,
@@ -233,6 +302,7 @@ module LLVM
     attach_function :LLVMConstVector, [:pointer, :uint], :pointer
     
     # Constant expressions
+    attach_function :LLVMGetConstOpcode, [:pointer], :opcode
     attach_function :LLVMAlignOf, [:pointer], :pointer
     attach_function :LLVMSizeOf, [:pointer], :pointer
     attach_function :LLVMConstNeg, [:pointer], :pointer

--- a/lib/llvm/core.rb
+++ b/lib/llvm/core.rb
@@ -275,6 +275,11 @@ module LLVM
     attach_function :LLVMSetValueName, [:pointer, :string], :void
     attach_function :LLVMDumpValue, [:pointer], :void
     
+    # Operations on Users
+    attach_function :LLVMGetOperand, [:pointer, :int], :pointer
+    attach_function :LLVMSetOperand, [:pointer, :int, :pointer], :void
+    attach_function :LLVMGetNumOperands, [:pointer], :int
+
     # Constants of any type
     attach_function :LLVMConstNull, [:pointer], :pointer
     attach_function :LLVMConstAllOnes, [:pointer], :pointer

--- a/lib/llvm/core.rb
+++ b/lib/llvm/core.rb
@@ -504,6 +504,7 @@ module LLVM
     # Pass managers
     attach_function :LLVMCreatePassManager, [], :pointer
     attach_function :LLVMCreateFunctionPassManager, [:pointer], :pointer
+    attach_function :LLVMCreateFunctionPassManagerForModule, [:pointer], :pointer
     attach_function :LLVMRunPassManager, [:pointer, :pointer], :int
     attach_function :LLVMInitializeFunctionPassManager, [:pointer], :int
     attach_function :LLVMRunFunctionPassManager, [:pointer, :pointer], :int

--- a/lib/llvm/core/builder.rb
+++ b/lib/llvm/core/builder.rb
@@ -1,19 +1,19 @@
 module LLVM
   class Builder
     private_class_method :new
-    
+
     def initialize(ptr) # :nodoc:
       @ptr = ptr
     end
-    
+
     def to_ptr # :nodoc:
       @ptr
     end
-    
+
     def self.create
       new(C.LLVMCreateBuilder())
     end
-    
+
     def position(block, instruction)
       raise "block must not be nil" if block.nil?
       C.LLVMPositionBuilder(self, block, instruction)
@@ -31,186 +31,177 @@ module LLVM
       C.LLVMPositionBuilderAtEnd(self, block)
       self
     end
-    
+
     def get_insert_block
       BasicBlock.from_ptr(C.LLVMGetInsertBlock(self))
     end
-    
+
     # Terminators
-    
+
     def ret_void
       Instruction.from_ptr(C.LLVMBuildRetVoid(self))
     end
-    
+
     def ret(val)
       Instruction.from_ptr(C.LLVMBuildRet(self, val))
     end
-    
+
     def aggregate_ret(*vals)
       FFI::MemoryPointer.new(FFI.type_size(:pointer) * vals.size) do |vals_ptr|
         vals_ptr.write_array_of_pointer(vals)
         Instruction.from_ptr(C.LLVMBuildAggregateRet(self, vals_ptr, vals.size))
       end
     end
-    
+
     def br(block)
       Instruction.from_ptr(
         C.LLVMBuildBr(self, block))
     end
-    
+
     def cond(cond, iftrue, iffalse)
       Instruction.from_ptr(
         C.LLVMBuildCondBr(self, cond, iftrue, iffalse))
     end
-    
+
     def switch(val, block, ncases)
       SwitchInst.from_ptr(C.LLVMBuildSwitch(self, val, block, ncases))
     end
-    
+
     def invoke(fun, args, _then, _catch, name = "")
       Instruction.from_ptr(
         C.LLVMBuildInvoke(self,
           fun, args, args.size, _then, _catch, name))
     end
-    
+
     def unwind
       Instruction.from_ptr(C.LLVMBuildUnwind(self))
     end
-    
+
     def unreachable
       Instruction.from_ptr(C.LLVMBuildUnreachable(self))
     end
-    
+
     # Arithmetic
-    
+
     def add(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildAdd(self, lhs, rhs, name))
     end
-    
+
     def nsw_add(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildNSWAdd(self, lhs, rhs, name))
     end
-    
+
     def fadd(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildFAdd(self, lhs, rhs, name))
     end
-    
+
     def sub(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildSub(self, lhs, rhs, name))
     end
-    
+
     def fsub(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildFSub(self, lhs, rhs, name))
     end
-    
+
     def mul(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildMul(self, lhs, rhs, name))
     end
-    
+
     def fmul(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildFMul(self, lhs, rhs, name))
     end
-    
+
     def udiv(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildUDiv(self, lhs, rhs, name))
     end
-    
+
     def sdiv(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildSDiv(self, lhs, rhs, name))
     end
-    
+
     def exact_sdiv(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildExactSDiv(self, lhs, rhs, name))
     end
-    
+
     def fdiv(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildFDiv(self, lhs, rhs, name))
     end
-    
+
     def urem(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildURem(self, lhs, rhs, name))
     end
-    
+
     def srem(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildSRem(self, lhs, rhs, name))
     end
-    
+
     def frem(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildFRem(self, lhs, rhs, name))
     end
-    
+
     def shl(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildShl(self, lhs, rhs, name))
     end
-    
+
     def lshr(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildLShr(self, lhs, rhs, name))
     end
-    
+
     def ashr(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildAShr(self, lhs, rhs, name))
     end
-    
+
     def and(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildAnd(self, lhs, rhs, name))
     end
-    
+
     def or(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildOr(self, lhs, rhs, name))
     end
-    
+
     def xor(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildXor(self, lhs, rhs, name))
     end
-    
+
     def neg(arg, name = "")
       Instruction.from_ptr(C.LLVMBuildNeg(self, arg, name))
     end
-    
+
     def not(arg, name = "")
       Instruction.from_ptr(C.LLVMBuildNot(self, arg, name))
     end
-    
+
     # Memory
-    
+
     def malloc(ty, name = "")
       Instruction.from_ptr(C.LLVMBuildMalloc(self, LLVM::Type(ty), name))
     end
-    
+
     def array_malloc(ty, val, name = "")
       Instruction.from_ptr(C.LLVMBuildArrayMalloc(self, LLVM::Type(ty), val, name))
     end
-    
+
     def alloca(ty, name = "")
       Instruction.from_ptr(C.LLVMBuildAlloca(self, LLVM::Type(ty), name))
     end
-    
+
     def array_alloca(ty, val, name = "")
       Instruction.from_ptr(C.LLVMBuildArrayAlloca(self, LLVM::Type(ty), val, name))
     end
-    
+
     def free(pointer)
       Instruction.from_ptr(C.LLVMBuildFree(self, pointer))
     end
-    
+
     def load(pointer, name = "")
       Instruction.from_ptr(C.LLVMBuildLoad(self, pointer, name))
     end
-    
+
     def store(val, pointer)
       Instruction.from_ptr(C.LLVMBuildStore(self, val, pointer))
     end
-    
+
     def gep(pointer, indices, name = "")
-      indices = Array(indices)
-      FFI::MemoryPointer.new(FFI.type_size(:pointer) * indices.size) do |indices_ptr|
-        indices_ptr.write_array_of_pointer(indices)
-        return Instruction.from_ptr(
-          C.LLVMBuildInBoundsGEP(self, pointer, indices_ptr, indices.size, name))
-      end
-    end
-    
-    def inbounds_gep(pointer, indices, name = "")
       indices = Array(indices)
       FFI::MemoryPointer.new(FFI.type_size(:pointer) * indices.size) do |indices_ptr|
         indices_ptr.write_array_of_pointer(indices)
@@ -218,105 +209,114 @@ module LLVM
           C.LLVMBuildGEP(self, pointer, indices_ptr, indices.size, name))
       end
     end
-    
+
+    def inbounds_gep(pointer, indices, name = "")
+      indices = Array(indices)
+      FFI::MemoryPointer.new(FFI.type_size(:pointer) * indices.size) do |indices_ptr|
+        indices_ptr.write_array_of_pointer(indices)
+        return Instruction.from_ptr(
+          C.LLVMBuildInBoundsGEP(self, pointer, indices_ptr, indices.size, name))
+      end
+    end
+
     def struct_gep(pointer, idx, name = "")
       Instruction.from_ptr(C.LLVMBuildStructGEP(self, pointer, idx, name))
     end
-    
+
     def global_string(string, name = "")
       Instruction.from_ptr(C.LLVMBuildGlobalString(self, string, name))
     end
-    
+
     def global_string_pointer(string, name = "")
       Instruction.from_ptr(C.LLVMBuildGlobalStringPtr(self, string, name))
     end
-    
+
     # Casts
-    
+
     def trunc(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildTrunc(self, val, LLVM::Type(ty), name))
     end
-    
+
     def zext(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildZExt(self, val, LLVM::Type(ty), name))
     end
-    
+
     def sext(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildSExt(self, val, LLVM::Type(ty), name))
     end
-    
+
     def fp2ui(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildFPToUI(self, val, LLVM::Type(ty), name))
     end
-    
+
     def fp2si(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildFPToSI(self, val, LLVM::Type(ty), name))
     end
-    
+
     def ui2fp(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildUIToFP(self, val, LLVM::Type(ty), name))
     end
-    
+
     def si2fp(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildSIToFP(self, val, LLVM::Type(ty), name))
     end
-    
+
     def fp_trunc(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildFPTrunc(self, val, LLVM::Type(ty), name))
     end
-    
+
     def fp_ext(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildFPExt(self, val, LLVM::Type(ty), name))
     end
-    
+
     def ptr2int(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildPtrToInt(self, val, LLVM::Type(ty), name))
     end
-    
+
     def int2ptr(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildIntToPtr(self, val, LLVM::Type(ty), name))
     end
-    
+
     def bit_cast(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildBitCast(self, val, LLVM::Type(ty), name))
     end
-    
+
     def zext_or_bit_cast(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildZExtOrBitCast(self, val, LLVM::Type(ty), name))
     end
-    
+
     def sext_or_bit_cast(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildSExtOrBitCast(self, val, LLVM::Type(ty), name))
     end
-    
+
     def trunc_or_bit_cast(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildTruncOrBitCast(self, val, LLVM::Type(ty), name))
     end
-    
+
     def pointer_cast(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildPointerCast(self, val, LLVM::Type(ty), name))
     end
-    
+
     def int_cast(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildIntCast(self, val, LLVM::Type(ty), name))
     end
-    
+
     def fp_cast(val, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildFPCast(self, val, LLVM::Type(ty), name))
     end
-    
+
     # Comparisons
-    
+
     def icmp(pred, lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildICmp(self, pred, lhs, rhs, name))
     end
-    
+
     def fcmp(pred, lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildFCmp(self, pred, lhs, rhs, name))
     end
-    
+
     # Misc
-    
+
     def phi(ty, *incoming)
       if incoming.last.kind_of? String
         name = incoming.pop
@@ -328,7 +328,7 @@ module LLVM
       phi.add_incoming(*incoming) unless incoming.empty?
       phi
     end
-    
+
     def call(fun, *args)
       raise "No fun" if fun.nil?
       if args.last.kind_of? String
@@ -341,47 +341,47 @@ module LLVM
       args_ptr.write_array_of_pointer(args)
       CallInst.from_ptr(C.LLVMBuildCall(self, fun, args_ptr, args.size, name))
     end
-    
+
     def select(_if, _then, _else, name = "")
       Instruction.from_ptr(C.LLVMBuildSelect(self, _if, _then, _else, name))
     end
-    
+
     def va_arg(list, ty, name = "")
       Instruction.from_ptr(C.LLVMBuildVAArg(self, list, LLVM::Type(ty), name))
     end
-    
+
     def extract_element(vector, index, name = "")
       Instruction.from_ptr(C.LLVMBuildExtractElement(self, vector, index, name))
     end
-    
+
     def insert_element(vector, elem, index, name = "")
       Instruction.from_ptr(C.LLVMBuildInsertElement(self, vector, elem, index, name))
     end
-    
+
     def shuffle_vector(vec1, vec2, mask, name = "")
       Instruction.from_ptr(C.LLVMBuildShuffleVector(self, vec1, vec2, mask, name))
     end
-    
+
     def extract_value(aggregate, index, name = "")
       Instruction.from_ptr(C.LLVMBuildExtractValue(self, aggregate, index, name))
     end
-    
+
     def insert_value(aggregate, elem, index, name = "")
       Instruction.from_ptr(C.LLVMBuildInsertValue(self, aggregate, elem, index, name))
     end
-    
+
     def is_null(val, name = "")
       Instruction.from_ptr(C.LLVMBuildIsNull(self, val, name))
     end
-    
+
     def is_not_null(val, name = "")
       Instruction.from_ptr(C.LLVMBuildIsNotNull(self, val, name))
     end
-    
+
     def ptr_diff(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildPtrDiff(lhs, rhs, name))
     end
-    
+
     def dispose
       C.LLVMDisposeBuilder(@ptr)
     end

--- a/lib/llvm/core/builder.rb
+++ b/lib/llvm/core/builder.rb
@@ -14,6 +14,18 @@ module LLVM
       new(C.LLVMCreateBuilder())
     end
     
+    def position(block, instruction)
+      raise "block must not be nil" if block.nil?
+      C.LLVMPositionBuilder(self, block, instruction)
+      self
+    end
+
+    def position_before(instruction)
+      raise "instruction must not be nil" if instruction.nil?
+      C.LLVMPositionBuilderBefore(self, instruction)
+      self
+    end
+
     def position_at_end(block)
       raise "block must not be nil" if block.nil?
       C.LLVMPositionBuilderAtEnd(self, block)

--- a/lib/llvm/core/builder.rb
+++ b/lib/llvm/core/builder.rb
@@ -308,7 +308,7 @@ module LLVM
     
     def phi(ty, *incoming)
       if incoming.last.kind_of? String
-        name = incomimg.pop
+        name = incoming.pop
       else
         name = ""
       end

--- a/lib/llvm/core/module.rb
+++ b/lib/llvm/core/module.rb
@@ -23,6 +23,10 @@ module LLVM
       end
     end
 
+    def eql?(other)
+      other.instance_of?(self.class) && self == other
+    end
+
     def self.create(name)
       new(C.LLVMModuleCreateWithName(name))
     end

--- a/lib/llvm/core/module.rb
+++ b/lib/llvm/core/module.rb
@@ -14,6 +14,15 @@ module LLVM
       @ptr
     end
     
+    def ==(other)
+      case other
+      when LLVM::Module
+        @ptr == other.to_ptr
+      else
+        false
+      end
+    end
+
     def self.create(name)
       new(C.LLVMModuleCreateWithName(name))
     end

--- a/lib/llvm/core/pass_manager.rb
+++ b/lib/llvm/core/pass_manager.rb
@@ -18,13 +18,40 @@ module LLVM
       send(:"#{name}!")
       self
     end
-    
+
+    def do_initialization
+    end
+
+    def do_finalization
+    end
+
     def run(mod)
       C.LLVMRunPassManager(self, mod)
     end
     
     def dispose
       C.LLVMDisposePassManager(self)
+    end
+  end
+
+  class FunctionPassManager < PassManager
+    def initialize(execution_engine, mod)
+      ptr = C.LLVMCreateFunctionPassManagerForModule(mod)
+      C.LLVMAddTargetData(
+        C.LLVMGetExecutionEngineTargetData(execution_engine), ptr)
+      @ptr = ptr
+    end
+
+    def do_initialization
+      !!C.LLVMInitializeFunctionPassManager(self)
+    end
+
+    def do_finalization
+      !!C.LLVMFinalizeFunctionPassManager(self)
+    end
+
+    def run(fn)
+      C.LLVMRunFunctionPassManager(self, fn)
     end
   end
 end

--- a/lib/llvm/core/pass_manager.rb
+++ b/lib/llvm/core/pass_manager.rb
@@ -43,11 +43,11 @@ module LLVM
     end
 
     def do_initialization
-      !!C.LLVMInitializeFunctionPassManager(self)
+      C.LLVMInitializeFunctionPassManager(self) != 0
     end
 
     def do_finalization
-      !!C.LLVMFinalizeFunctionPassManager(self)
+      C.LLVMFinalizeFunctionPassManager(self) != 0
     end
 
     def run(fn)

--- a/lib/llvm/core/pass_manager.rb
+++ b/lib/llvm/core/pass_manager.rb
@@ -1,7 +1,6 @@
 module LLVM
   # The PassManager runs a queue of passes on a module. See
   # http://llvm.org/docs/Passes.html for the list of available passes.
-  # Currently, only scalar transformation passes are supported.
   class PassManager
     def initialize(execution_engine)
       ptr = C.LLVMCreatePassManager()

--- a/lib/llvm/core/type.rb
+++ b/lib/llvm/core/type.rb
@@ -20,6 +20,10 @@ module LLVM
       end
     end
 
+    def kind
+        C.LLVMGetTypeKind(self)
+    end
+
     def size
       Int64.from_ptr(C.LLVMSizeOf(self))
     end

--- a/lib/llvm/core/type.rb
+++ b/lib/llvm/core/type.rb
@@ -32,6 +32,13 @@ module LLVM
       Int64.from_ptr(C.LLVMAlignOf(self))
     end
 
+    def element_type
+      case self.kind
+      when :pointer, :vector, :array
+        Type.from_ptr(C.LLVMGetElementType(self))
+      end
+    end
+
     def null_pointer
       ConstantExpr.from_ptr(C.LLVMConstPointerNull(self))
     end

--- a/lib/llvm/core/type.rb
+++ b/lib/llvm/core/type.rb
@@ -71,11 +71,11 @@ module LLVM
       from_ptr(C.LLVMVectorType(LLVM::Type(ty), element_count))
     end
     
-    def self.function(arg_types, result_type)
+    def self.function(arg_types, result_type, options = {})
       arg_types.map! { |ty| LLVM::Type(ty) }
       arg_types_ptr = FFI::MemoryPointer.new(FFI.type_size(:pointer) * arg_types.size)
       arg_types_ptr.write_array_of_pointer(arg_types)
-      from_ptr(C.LLVMFunctionType(LLVM::Type(result_type), arg_types_ptr, arg_types.size, 0))
+      from_ptr(C.LLVMFunctionType(LLVM::Type(result_type), arg_types_ptr, arg_types.size, options[:varargs] ? 1 : 0))
     end
     
     def self.struct(elt_types, is_packed)
@@ -124,8 +124,8 @@ module LLVM
     LLVM::Type.vector(ty, sz)
   end
   
-  def LLVM.Function(argtypes, rettype)
-    LLVM::Type.function(argtypes, rettype)
+  def LLVM.Function(argtypes, rettype, options = {})
+    LLVM::Type.function(argtypes, rettype, options)
   end
   
   def LLVM.Struct(*elt_types)

--- a/lib/llvm/core/type.rb
+++ b/lib/llvm/core/type.rb
@@ -20,6 +20,10 @@ module LLVM
       end
     end
 
+    def eql?(other)
+      other.instance_of?(self.class) && self == other
+    end
+
     def kind
         C.LLVMGetTypeKind(self)
     end

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -415,19 +415,10 @@ module LLVM
     end
     
     class ParameterCollection
-      include Enumerable
-
       def initialize(fun)
         @fun = fun
       end
       
-      def each
-        return Enumerator.new(self) unless block_given?
-        n = size
-        0.upto(n-1) {|i| yield self[i] }
-        self
-      end
-
       def [](i)
         Value.from_ptr(C.LLVMGetParam(@fun, i))
       end
@@ -439,7 +430,9 @@ module LLVM
       include Enumerable
       
       def each
+        return to_enum :each unless block_given?
         0.upto(size-1) { |i| yield self[i] }
+        self
       end
     end
   end

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -100,6 +100,16 @@ module LLVM
       LLVM::Function.from_ptr(fp)
     end
 
+    def next
+      ptr = C.LLVMGetNextBasicBlock(self)
+      BasicBlock.from_ptr(ptr) unless ptr.null?
+    end
+
+    def previous
+      ptr = C.LLVMGetPreviousBasicBlock(self)
+      BasicBlock.from_ptr(ptr) unless ptr.null?
+    end
+
     def first_instruction
       ptr = C.LLVMGetFirstInstruction(self)
       LLVM::Instruction.from_ptr(ptr) unless ptr.null?
@@ -462,6 +472,18 @@ module LLVM
 
       def size
         C.LLVMCountBasicBlocks(@fun)
+      end
+
+      def each
+        return to_enum :each unless block_given?
+
+        ptr = C.LLVMGetFirstBasicBlock(@fun)
+        0.upto(size-1) do |i|
+          yield BasicBlock.from_ptr(ptr)
+          ptr = C.LLVMGetNextBasicBlock(ptr)
+        end
+
+        self
       end
 
       def append(name = "")

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -97,7 +97,7 @@ module LLVM
 
     def parent
       fp = C.LLVMGetBasicBlockParent(self)
-      LLVM::Function.from_ptr(fp)
+      LLVM::Function.from_ptr(fp) unless fp.null?
     end
 
     def next

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -81,7 +81,7 @@ module LLVM
       builder.position_at_end(self)
       yield builder
     ensure
-      builder.dispose
+      builder.dispose if islocal
     end
   end
   

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -418,6 +418,16 @@ module LLVM
       def entry
         BasicBlock.from_ptr(C.LLVMGetEntryBasicBlock(@fun))
       end
+
+      def first
+        ptr = C.LLVMGetFirstBasicBlock(@fun)
+        BasicBlock.from_ptr(ptr) unless ptr.null?
+      end
+
+      def last
+        ptr = C.LLVMGetLastBasicBlock(@fun)
+        BasicBlock.from_ptr(ptr) unless ptr.null?
+      end
     end
     
     def params

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -83,6 +83,11 @@ module LLVM
     ensure
       builder.dispose if islocal
     end
+
+    def parent
+      fp = C.LLVMGetBasicBlockParent(self)
+      LLVM::Function.from_ptr(fp)
+    end
   end
   
   class Constant < Value

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -466,6 +466,8 @@ module LLVM
     end
 
     class BasicBlockCollection
+      include Enumerable
+
       def initialize(fun)
         @fun = fun
       end

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -374,10 +374,19 @@ module LLVM
     end
     
     class ParameterCollection
+      include Enumerable
+
       def initialize(fun)
         @fun = fun
       end
       
+      def each
+        return Enumerator.new(self) unless block_given?
+        n = size
+        0.upto(n-1) {|i| yield self[i] }
+        self
+      end
+
       def [](i)
         Value.from_ptr(C.LLVMGetParam(@fun, i))
       end

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -14,6 +14,15 @@ module LLVM
       @ptr
     end
 
+    def ==(other)
+      case other
+      when LLVM::Value
+        @ptr == other.to_ptr
+      else
+        false
+      end
+    end
+
     def self.type
       raise NotImplementedError, "#{self.name}.type() is abstract."
     end

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -71,6 +71,10 @@ module LLVM
   end
   
   class BasicBlock < Value
+    def self.create(fun = nil, name = "")
+      self.from_ptr(C.LLVMAppendBasicBlock(fun, name))
+    end
+
     def build(builder = nil)
       if builder.nil?
         builder = Builder.create
@@ -366,7 +370,7 @@ module LLVM
       end
       
       def append(name = "")
-        BasicBlock.from_ptr(C.LLVMAppendBasicBlock(@fun, name))
+        BasicBlock.create(@fun, name)
       end
       
       def entry

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -557,6 +557,20 @@ module LLVM
   end
 
   class Instruction < User
+    def parent
+      ptr = C.LLVMGetInstructionParent(self)
+      LLVM::BasicBlock.from_ptr(ptr) unless ptr.null?
+    end
+
+    def next
+      ptr = C.LLVMGetNextInstruction(self)
+      LLVM::Instruction.from_ptr(ptr) unless ptr.null?
+    end
+
+    def previous
+      ptr = C.LLVMGetPreviousInstruction(self)
+      LLVM::Instruction.from_ptr(ptr) unless ptr.null?
+    end
   end
 
   class CallInst < Instruction

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -90,6 +90,16 @@ module LLVM
       fp = C.LLVMGetBasicBlockParent(self)
       LLVM::Function.from_ptr(fp)
     end
+
+    def first_instruction
+      ptr = C.LLVMGetFirstInstruction(self)
+      LLVM::Instruction.from_ptr(ptr) unless ptr.null?
+    end
+
+    def last_instruction
+      ptr = C.LLVMGetLastInstruction(self)
+      LLVM::Instruction.from_ptr(ptr) unless ptr.null?
+    end
   end
   
   class Constant < Value

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -23,6 +23,10 @@ module LLVM
       end
     end
 
+    def eql?(other)
+      other.instance_of?(self.class) && self == other
+    end
+
     def self.type
       raise NotImplementedError, "#{self.name}.type() is abstract."
     end

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -78,6 +78,8 @@ module LLVM
   end
 
   class BasicBlock < Value
+    include Enumerable
+
     def self.create(fun = nil, name = "")
       self.from_ptr(C.LLVMAppendBasicBlock(fun, name))
     end
@@ -108,6 +110,20 @@ module LLVM
     def previous
       ptr = C.LLVMGetPreviousBasicBlock(self)
       BasicBlock.from_ptr(ptr) unless ptr.null?
+    end
+
+    def each
+      return to_enum :each unless block_given?
+      inst = first_instruction
+      last = last_instruction
+
+      while inst
+        yield inst
+        break if inst == last
+        inst = inst.next
+      end
+
+      self
     end
 
     def first_instruction

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -3,71 +3,71 @@ module LLVM
     def self.from_ptr(ptr)
       new(ptr) unless ptr.null?
     end
-    
+
     private_class_method :new
-    
+
     def initialize(ptr)
       @ptr = ptr
     end
-    
+
     def to_ptr # :nodoc:
       @ptr
     end
-    
+
     def self.type
       raise NotImplementedError, "#{self.name}.type() is abstract."
     end
-    
+
     def self.to_ptr
       type.to_ptr
     end
-    
+
     def type
       Type.from_ptr(C.LLVMTypeOf(self))
     end
-    
+
     def name
       C.LLVMGetValueName(self)
     end
-    
+
     def name=(str)
       C.LLVMSetValueName(self, str)
       str
     end
-    
+
     def dump
       C.LLVMDumpValue(self)
     end
-    
+
     def constant?
       case C.LLVMIsConstant(self)
       when 0 then false
       when 1 then true
       end
     end
-    
+
     def null?
       case C.LLVMIsNull(self)
       when 0 then false
       when 1 then true
       end
     end
-    
+
     def undefined?
       case C.LLVMIsUndef(self)
       when 0 then false
       when 1 then true
       end
     end
-    
+
     def add_attribute(attr)
       C.LLVMAddAttribute(self, attr)
     end
   end
-  
+
   class Argument < Value
   end
-  
+
   class BasicBlock < Value
     def self.create(fun = nil, name = "")
       self.from_ptr(C.LLVMAppendBasicBlock(fun, name))
@@ -139,11 +139,11 @@ module LLVM
     def self.null
       from_ptr(C.LLVMConstNull(type))
     end
-    
+
     def self.undef
       from_ptr(C.LLVMGetUndef(type))
     end
-    
+
     def self.null_ptr
       from_ptr(C.LLVMConstPointerNull(type))
     end
@@ -161,7 +161,7 @@ module LLVM
       end
     end
   end
-  
+
   module Support
     def allocate_pointers(size_or_values, &block)
       if size_or_values.is_a?(Integer)
@@ -185,7 +185,7 @@ module LLVM
     def self.string(str, null_terminate = true)
       from_ptr(C.LLVMConstString(str, str.length, null_terminate ? 0 : 1))
     end
-    
+
     # ConstantArray.const(type, 3) {|i| ... } or
     # ConstantArray.const(type, [...])
     def self.const(type, size_or_values, &block)
@@ -193,88 +193,88 @@ module LLVM
       from_ptr C.LLVMConstArray(type, vals, vals.size / vals.type_size)
     end
   end
-  
+
   class ConstantExpr < Constant
   end
-  
+
   class ConstantInt < Constant
     def self.all_ones
       from_ptr(C.LLVMConstAllOnes(type))
     end
-    
+
     def self.from_i(n, signed = true)
       from_ptr(C.LLVMConstInt(type, n, signed ? 1 : 0))
     end
-    
+
     def self.parse(str, radix = 10)
       from_ptr(C.LLVMConstIntOfString(type, str, radix))
     end
-    
+
     def -@
       self.class.from_ptr(C.LLVMConstNeg(self))
     end
-    
+
     def not
       self.class.from_ptr(C.LLVMConstNot(self))
     end
-    
+
     def +(rhs)
       self.class.from_ptr(C.LLVMConstAdd(self, rhs))
     end
-    
+
     def nsw_add(rhs)
       self.class.from_ptr(C.LLVMConstNSWAdd(self, rhs))
     end
-    
+
     def *(rhs)
       self.class.from_ptr(C.LLVMConstMul(self, rhs))
     end
-    
+
     def udiv(rhs)
       self.class.from_ptr(C.LLVMConstUDiv(self, rhs))
     end
-    
+
     def /(rhs)
       self.class.from_ptr(C.LLVMConstSDiv(self, rhs))
     end
-    
+
     def urem(rhs)
       self.class.from_ptr(C.LLVMConstURem(self, rhs))
     end
-    
+
     def rem(rhs)
       self.class.from_ptr(C.LLVMConstSRem(self, rhs))
     end
-    
+
     def and(rhs) # Ruby's && cannot be overloaded
       self.class.from_ptr(C.LLVMConstAnd(self, rhs))
     end
-    
+
     def or(rhs) # Nor is ||.
       self.class.from_ptr(C.LLVMConstOr(self, rhs))
     end
-    
+
     def xor(rhs) # Nor is ||.
       self.class.from_ptr(C.LLVMConstXor(self, rhs))
     end
-    
+
     def icmp(pred, rhs)
       self.class.from_ptr(C.LLVMConstICmp(pred, self, rhs))
     end
-    
+
     def <<(bits)
       self.class.from_ptr(C.LLVMConstShl(self, rhs))
     end
-    
+
     def >>(bits)
       self.class.from_ptr(C.LLVMConstLShr(self, rhs))
     end
-    
+
     def ashr(bits)
       self.class.from_ptr(C.LLVMConstAShr(self, rhs))
     end
   end
-  
+
   def LLVM.const_missing(const) # :nodoc:
     case const.to_s
     when /Int(\d+)/
@@ -292,71 +292,71 @@ module LLVM
       super
     end
   end
-  
+
   # Native integer type
   ::LLVM::Int = const_get("Int#{NATIVE_INT_SIZE}")
-  
+
   def LLVM.Int(val)
     case val
     when LLVM::ConstantInt then val
     when Integer then Int.from_i(val)
     end
   end
-  
+
   class ConstantReal < Constant
     def self.from_f(n)
       from_ptr(C.LLVMConstReal(type, n))
     end
-    
+
     def self.parse(str)
       from_ptr(C.LLVMConstRealOfString(type, str))
     end
-    
+
     def -@
       self.class.from_ptr(C.LLVMConstFNeg(self))
     end
-    
+
     def +(rhs)
       self.class.from_ptr(C.LLVMConstFAdd(self, rhs))
     end
-    
+
     def *(rhs)
       self.class.from_ptr(C.LLVMConstFMul(self, rhs))
     end
-    
+
     def /(rhs)
       self.class.from_ptr(C.LLVMConstFDiv(self, rhs))
     end
-    
+
     def rem(rhs)
       self.class.from_ptr(C.LLVMConstFRem(self, rhs))
     end
-    
+
     def fcmp(pred, rhs)
       self.class.from_ptr(C.LLMVConstFCmp(pred, self, rhs))
     end
   end
-  
+
   class Float < ConstantReal
     def self.type
       Type.from_ptr(C.LLVMFloatType)
     end
   end
-  
+
   def LLVM.Float(val)
     Float.from_f(val)
   end
-  
+
   class Double < ConstantReal
     def self.type
       Type.from_ptr(C.LLVMDoubleType)
     end
   end
-  
+
   def LLVM.Double(val)
     Double.from_f(val)
   end
-  
+
   class ConstantStruct < Constant
     # ConstantStruct.const(size) {|i| ... } or
     # ConstantStruct.const([...])
@@ -365,51 +365,51 @@ module LLVM
       from_ptr C.LLVMConstStruct(vals, vals.size / vals.type_size, packed ? 1 : 0)
     end
   end
-  
+
   class ConstantVector < Constant
     def self.all_ones
       from_ptr(C.LLVMConstAllOnes(type))
     end
-    
-    def self.const(size)
-      vals = (0..size).map { |i| yield i }
-      from_ptr(C.LLVMConstVector(vals, size))
+
+    def self.const(size_or_values, &block)
+      vals = LLVM::Support.allocate_pointers(size_or_values, &block)
+      from_ptr(C.LLVMConstVector(vals, vals.size / vals.type_size))
     end
   end
-  
+
   class GlobalValue < Constant
     def declaration?
       C.LLVMIsDeclaration(self)
     end
-    
+
     def linkage
       C.LLVMGetLinkage(self)
     end
-    
+
     def linkage=(linkage)
       C.LLVMSetLinkage(self, linkage)
     end
-    
+
     def section
       C.LLVMGetSection(self)
     end
-    
+
     def section=(section)
       C.LLVMSetSection(self, section)
     end
-    
+
     def visibility
       C.LLVMGetVisibility(self)
     end
-    
+
     def visibility=(viz)
       C.LLVMSetVisibility(self, viz)
     end
-    
+
     def alignment
       C.LLVMGetAlignment(self)
     end
-    
+
     def alignment=(bytes)
       C.LLVMSetAlignment(self, bytes)
     end
@@ -430,38 +430,38 @@ module LLVM
       C.LLVMSetGlobalConstant(self, flag)
     end
   end
-  
+
   class Function < GlobalValue
     def call_conv=(conv)
       C.LLVMSetFunctionCallConv(self, conv)
       conv
     end
-    
+
     def add_attribute(attr)
       C.LLVMAddFunctionAttr(self, attr)
     end
-    
+
     def remove_attribute(attr)
       C.LLVMRemoveFunctionAttr(self, attr)
     end
-    
+
     def basic_blocks
       @basic_block_collection ||= BasicBlockCollection.new(self)
     end
-    
+
     class BasicBlockCollection
       def initialize(fun)
         @fun = fun
       end
-      
+
       def size
         C.LLVMCountBasicBlocks(@fun)
       end
-      
+
       def append(name = "")
         BasicBlock.create(@fun, name)
       end
-      
+
       def entry
         BasicBlock.from_ptr(C.LLVMGetEntryBasicBlock(@fun))
       end
@@ -476,26 +476,26 @@ module LLVM
         BasicBlock.from_ptr(ptr) unless ptr.null?
       end
     end
-    
+
     def params
       @parameter_collection ||= ParameterCollection.new(self)
     end
-    
+
     class ParameterCollection
       def initialize(fun)
         @fun = fun
       end
-      
+
       def [](i)
         Value.from_ptr(C.LLVMGetParam(@fun, i))
       end
-      
+
       def size
         C.LLVMCountParams(@fun)
       end
-      
+
       include Enumerable
-      
+
       def each
         return to_enum :each unless block_given?
         0.upto(size-1) { |i| yield self[i] }
@@ -503,45 +503,45 @@ module LLVM
       end
     end
   end
-  
+
   class GlobalAlias < GlobalValue
   end
-  
+
   class GlobalVariable < GlobalValue
     def initializer
       Value.from_ptr(C.LLVMGetInitializer(self))
     end
-    
+
     def initializer=(val)
       C.LLVMSetInitializer(self, val)
     end
-    
+
     def thread_local?
       case C.LLVMIsThreadLocal(self)
       when 0 then false
       else true
       end
     end
-    
+
     def thread_local=(local)
       C.LLVMSetThreadLocal(self, local ? 1 : 0)
     end
   end
-  
+
   class Instruction < User
   end
-  
+
   class CallInst < Instruction
     def call_conv=(conv)
       C.LLVMSetInstructionCallConv(self, conv)
       conv
     end
-    
+
     def call_conv
       C.LLVMGetInstructionCallConv(self)
     end
   end
-  
+
   class Phi < Instruction
     # Add incoming branches to a phi node by passing an alternating list
     # of resulting values and basic blocks. e.g.
@@ -551,11 +551,11 @@ module LLVM
       incoming.each_with_index do |node, i|
         (i % 2 == 0 ? vals : blocks) << node
       end
-      
+
       unless vals.size == blocks.size
         raise ArgumentError, "Expected vals.size and blocks.size to match"
       end
-      
+
       size = vals.size
       FFI::MemoryPointer.new(FFI.type_size(:pointer) * size) do |vals_ptr|
         vals_ptr.write_array_of_pointer(vals)
@@ -564,11 +564,11 @@ module LLVM
           C.LLVMAddIncoming(self, vals_ptr, blocks_ptr, vals.size)
         end
       end
-      
+
       nil
     end
   end
-  
+
   class SwitchInst < Instruction
     # Adds a case to a switch instruction. First the value to match on,
     # then the basic block.

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -172,10 +172,7 @@ module LLVM
         values = size_or_values
         size = values.size
       end
-
-      mp = FFI::MemoryPointer.new(:pointer, size)
-      values.each_with_index { |p, i| mp[i].put_pointer(0, p) }
-      mp
+      FFI::MemoryPointer.new(:pointer, size).write_array_of_pointer(values)
     end
 
     module_function :allocate_pointers

--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -9,66 +9,66 @@ module LLVM
     attach_function :LLVMCreateGenericValueOfInt, [:pointer, :long_long, :int], :pointer
     attach_function :LLVMCreateGenericValueOfPointer, [:pointer], :pointer
     attach_function :LLVMCreateGenericValueOfFloat, [:pointer, :double], :pointer
-    
+
     attach_function :LLVMGenericValueIntWidth, [:pointer], :uint
-    
+
     attach_function :LLVMGenericValueToInt, [:pointer, :int], :long_long
     attach_function :LLVMGenericValueToPointer, [:pointer], :pointer
     attach_function :LLVMGenericValueToFloat, [:pointer, :pointer], :double
     attach_function :LLVMDisposeGenericValue, [:pointer], :void
-    
+
     # Execution engines
     attach_function :LLVMCreateExecutionEngineForModule, [:pointer, :pointer, :pointer], :int
     attach_function :LLVMCreateInterpreterForModule, [:pointer, :pointer, :pointer], :int
     attach_function :LLVMCreateJITCompilerForModule, [:pointer, :pointer, :uint, :pointer], :int
     attach_function :LLVMDisposeExecutionEngine, [:pointer], :void
-    
+
     attach_function :LLVMRunStaticConstructors, [:pointer], :void
     attach_function :LLVMRunStaticDestructors, [:pointer], :void
-    
+
     attach_function :LLVMRunFunctionAsMain, [:pointer, :pointer, :uint, :pointer, :pointer], :int
     attach_function :LLVMRunFunction, [:pointer, :pointer, :uint, :pointer], :pointer
-    
+
     attach_function :LLVMFreeMachineCodeForFunction, [:pointer, :pointer], :void
     attach_function :LLVMAddModuleProvider, [:pointer, :pointer], :void
     attach_function :LLVMRemoveModuleProvider, [:pointer, :pointer, :pointer, :pointer], :int
-    
+
     attach_function :LLVMFindFunction, [:pointer, :pointer, :pointer, :pointer], :int
-    
+
     attach_function :LLVMGetExecutionEngineTargetData, [:pointer], :pointer
-    
+
     attach_function :LLVMAddGlobalMapping, [:pointer, :pointer, :pointer], :void
-    
+
     attach_function :LLVMGetPointerToGlobal, [:pointer, :pointer], :pointer
-    
+
     attach_function :LLVMInitializeX86TargetInfo, [], :void
-    
+
     attach_function :LLVMInitializeX86Target, [], :void
   end
-  
+
   def LLVM.init_x86
     LLVM::C.LLVMInitializeX86Target
     LLVM::C.LLVMInitializeX86TargetInfo
   end
-  
+
   class ExecutionEngine
     private_class_method :new
-    
+
     def initialize(ptr) # :nodoc:
       @ptr = ptr
     end
-    
+
     def to_ptr # :nodoc:
       @ptr
     end
-    
+
     def self.create_jit_compiler(mod, opt_level = 3)
       FFI::MemoryPointer.new(FFI.type_size(:pointer)) do |ptr|
         error   = FFI::MemoryPointer.new(FFI.type_size(:pointer))
         status  = C.LLVMCreateJITCompilerForModule(ptr, mod, opt_level, error)
         errorp  = error.read_pointer
         message = errorp.read_string unless errorp.null?
-        
+
         if status.zero?
           return new(ptr.read_pointer)
         else
@@ -78,7 +78,7 @@ module LLVM
         end
       end
     end
-    
+
     def run_function(fun, *args)
       FFI::MemoryPointer.new(FFI.type_size(:pointer) * args.size) do |args_ptr|
         args_ptr.write_array_of_pointer(args.map { |arg| LLVM.GenericValue(arg).to_ptr })
@@ -86,50 +86,50 @@ module LLVM
           C.LLVMRunFunction(self, fun, args.size, args_ptr))
       end
     end
-    
+
     def pointer_to_global(global)
       C.LLVMGetPointerToGlobal(self, global)
     end
   end
-  
+
   class GenericValue
     private_class_method :new
 
     def initialize(ptr) # :nodoc:
       @ptr = ptr
     end
-    
+
     def to_ptr # :nodoc:
       @ptr
     end
-    
+
     def self.from_i(i, type = LLVM::Int, signed = true)
       new(C.LLVMCreateGenericValueOfInt(type, i, signed ? 1 : 0))
     end
-    
+
     def self.from_f(f)
       type = LLVM::Float.type
       new(C.LLVMCreateGenericValueOfFloat(type, f))
     end
-    
+
     def self.from_ptr(ptr)
       new(ptr)
     end
-    
+
     def to_i(signed = true)
       C.LLVMGenericValueToInt(self, signed ? 1 : 0)
     end
-    
+
     def to_f(type = LLVM::Float.type)
       C.LLVMGenericValueToFloat(type, self)
     end
   end
-  
+
   def GenericValue(val)
     case val
     when GenericValue then val
-    when Integer then GenericValue.from_i(val)
-    when Float then GenericValue.from_f(val)
+    when ::Integer then GenericValue.from_i(val)
+    when ::Float then GenericValue.from_f(val)
     end
   end
   module_function :GenericValue

--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -111,6 +111,10 @@ module LLVM
       type = LLVM::Float.type
       new(C.LLVMCreateGenericValueOfFloat(type, f))
     end
+    
+    def self.from_b(b)
+      from_i(b ? 1 : 0, LLVM::Int1, false)
+    end
 
     def self.from_ptr(ptr)
       new(ptr)
@@ -123,6 +127,11 @@ module LLVM
     def to_f(type = LLVM::Float.type)
       C.LLVMGenericValueToFloat(type, self)
     end
+    
+    def to_b
+      to_i(false) != 0
+    end
+    
   end
 
   def GenericValue(val)
@@ -130,6 +139,8 @@ module LLVM
     when GenericValue then val
     when ::Integer then GenericValue.from_i(val)
     when ::Float then GenericValue.from_f(val)
+    when ::TrueClass then GenericValue.from_b(true)
+    when ::FalseClass then GenericValue.from_b(false)
     end
   end
   module_function :GenericValue

--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -75,6 +75,7 @@ module LLVM
           return new(ptr.read_pointer)
         else
           C.LLVMDisposeMessage(error)
+          error.autorelease=false
           raise RuntimeError, "Error creating JIT compiler: #{message}"
         end
       end

--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -124,8 +124,8 @@ module LLVM
       C.LLVMGenericValueToInt(self, signed ? 1 : 0)
     end
     
-    def to_f
-      C.LLVMGenericValueToFloat(LLVM::Float.type, self)
+    def to_f(type = LLVM::Float.type)
+      C.LLVMGenericValueToFloat(type, self)
     end
   end
   

--- a/lib/llvm/transforms/ipo.rb
+++ b/lib/llvm/transforms/ipo.rb
@@ -1,0 +1,15 @@
+# Interprocedural optimization (IPO)
+require 'llvm'
+require 'llvm/core'
+
+module LLVM
+  module C
+    attach_function :LLVMAddGlobalDCEPass, [:pointer], :void
+  end
+
+  class PassManager
+    def gdce!
+      C.LLVMAddGlobalDCEPass(self)
+    end
+  end
+end

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class ArrayTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_constant_array_from_size
+    array = LLVM::ConstantArray.const(LLVM::Int, 2) { |i| LLVM::Int(i) }
+    assert_instance_of LLVM::ConstantArray, array
+    assert_equal 2, array.operands.size
+  end
+
+  def test_constant_array_from_array
+    array = LLVM::ConstantArray.const(LLVM::Int, [LLVM::Int(0), LLVM::Int(1)])
+    assert_instance_of LLVM::ConstantArray, array
+    assert_equal 2, array.operands.size
+  end
+
+  def test_array_values
+    assert_equal 2 + 3, run_array_values(2, 3).to_i
+  end
+
+  def run_array_values(value1, value2)
+    run_function([LLVM::Int, LLVM::Int], [value1, value2], LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      pointer = builder.alloca(LLVM::Array(LLVM::Int, 2))
+      array = builder.load(pointer)
+      array = builder.insert_value(array, arguments.first, 0)
+      array = builder.insert_value(array, arguments.last, 1)
+      builder.ret(builder.add(builder.extract_value(array, 0),
+                              builder.extract_value(array, 1)))
+    end
+  end
+
+end

--- a/test/basic_block_test.rb
+++ b/test/basic_block_test.rb
@@ -70,7 +70,7 @@ class BasicBlockTestCase < Test::Unit::TestCase
       end
 
       block1.build do |builder|
-				builder.ret(builder.fadd(arg, LLVM.Double(1.0)))
+        builder.ret(builder.fadd(arg, LLVM.Double(1.0)))
       end
 
       [ block1.instructions.to_a, block1.instructions.each.to_a ].each do |insts|

--- a/test/basic_block_test.rb
+++ b/test/basic_block_test.rb
@@ -61,5 +61,26 @@ class BasicBlockTestCase < Test::Unit::TestCase
     end
   end
 
+  def test_basic_block_enumerable
+    @module.functions.add("test_basic_block_enumerable", [LLVM::Double], LLVM::Double) do |fn, arg|
+      block1 = fn.basic_blocks.append
+
+      [ block1.to_a, block1.each.to_a ].each do |insts|
+        assert_equal 0, insts.size, 'Empty basic block'
+      end
+
+      block1.build do |builder|
+				builder.ret(builder.fadd(arg, LLVM.Double(1.0)))
+      end
+
+      [ block1.to_a, block1.each.to_a ].each do |insts|
+        assert_equal 2, insts.size
+        assert_equal block1.first_instruction, insts[0]
+        assert_equal block1.last_instruction, insts[1]
+      end
+
+    end
+  end
+
 end
 

--- a/test/basic_block_test.rb
+++ b/test/basic_block_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class BasicBlockTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+    @module = LLVM::Module.create("BasicBlockTestCase")
+  end
+
+  def test_basic_block_collection
+    @module.functions.add("test_basic_block_collection", [], LLVM.Void) do |fn|
+      coll = fn.basic_blocks
+
+      block1 = coll.append
+      assert_instance_of LLVM::BasicBlock, block1
+
+      assert_equal 1, coll.size
+      assert_equal coll.first, coll.last,
+                   'Only one block exists in the function'
+      assert_equal coll.first, coll.entry,
+                   'The entry block for the function is always the first block'
+
+      block2 = coll.append
+      assert_equal 2, coll.size
+      assert_equal block1, coll.first
+      assert_equal block2, coll.last
+
+      blocks = coll.each.to_a
+      assert_equal 2, blocks.size
+      assert_equal block1, blocks[0]
+      assert_equal block2, blocks[1]
+    end
+  end
+
+  def test_basic_block
+    @module.functions.add("test_basic_block", [], LLVM.Void) do |fn|
+      coll = fn.basic_blocks
+
+      block1 = coll.append
+      block2 = coll.append
+
+      assert_equal fn, block1.parent
+      assert_equal fn, block2.parent
+
+      assert_equal block2, block1.next
+      assert_equal block1, block2.previous
+
+      block1.build do |builder|
+        builder.br(block2)
+      end
+
+      block2.build do |builder|
+        builder.ret_void
+      end
+
+      assert_equal block1.first_instruction,
+                   block1.last_instruction
+      assert_equal block2.first_instruction,
+                   block2.last_instruction
+    end
+  end
+
+end
+

--- a/test/basic_block_test.rb
+++ b/test/basic_block_test.rb
@@ -65,7 +65,7 @@ class BasicBlockTestCase < Test::Unit::TestCase
     @module.functions.add("test_basic_block_enumerable", [LLVM::Double], LLVM::Double) do |fn, arg|
       block1 = fn.basic_blocks.append
 
-      [ block1.to_a, block1.each.to_a ].each do |insts|
+      [ block1.instructions.to_a, block1.instructions.each.to_a ].each do |insts|
         assert_equal 0, insts.size, 'Empty basic block'
       end
 
@@ -73,10 +73,12 @@ class BasicBlockTestCase < Test::Unit::TestCase
 				builder.ret(builder.fadd(arg, LLVM.Double(1.0)))
       end
 
-      [ block1.to_a, block1.each.to_a ].each do |insts|
+      [ block1.instructions.to_a, block1.instructions.each.to_a ].each do |insts|
         assert_equal 2, insts.size
-        assert_equal block1.first_instruction, insts[0]
-        assert_equal block1.last_instruction, insts[1]
+        assert_equal block1.first_instruction, insts[0]  # deprecated
+        assert_equal block1.last_instruction,  insts[1]  # deprecated
+        assert_equal block1.instructions.first, insts[0]
+        assert_equal block1.instructions.last,  insts[1]
       end
 
     end

--- a/test/basic_block_test.rb
+++ b/test/basic_block_test.rb
@@ -25,10 +25,11 @@ class BasicBlockTestCase < Test::Unit::TestCase
       assert_equal block1, coll.first
       assert_equal block2, coll.last
 
-      blocks = coll.each.to_a
-      assert_equal 2, blocks.size
-      assert_equal block1, blocks[0]
-      assert_equal block2, blocks[1]
+      [ coll.each.to_a, coll.to_a ].each do |blocks|
+        assert_equal 2, blocks.size
+        assert_equal block1, blocks[0]
+        assert_equal block2, blocks[1]
+      end
     end
   end
 

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class BasicTestCase < Test::Unit::TestCase
+
+  def test_llvm_initialization
+    assert_nothing_raised do
+      LLVM.init_x86
+    end
+  end
+
+end

--- a/test/binary_operations_test.rb
+++ b/test/binary_operations_test.rb
@@ -7,30 +7,30 @@ class BasicOperationsTestCase < Test::Unit::TestCase
   end
 
   def test_integer_binary_operations
-    integer_binary_operation_assertion(:add, 3, 2, 5)
-    integer_binary_operation_assertion(:sub, 3, 2, 1)
-    integer_binary_operation_assertion(:mul, 3, 2, 6)
-    integer_binary_operation_assertion(:udiv, 10, 2, 5)
-    integer_binary_operation_assertion(:sdiv, 10, 2, 5)
-    integer_binary_operation_assertion(:urem, 10, 3, 1)
-    integer_binary_operation_assertion(:srem, 10, 3, 1)
+    integer_binary_operation_assertion(:add, 3, 2, 3 + 2)
+    integer_binary_operation_assertion(:sub, 3, 2, 3 - 2)
+    integer_binary_operation_assertion(:mul, 3, 2, 3 * 2)
+    integer_binary_operation_assertion(:udiv, 10, 2, 10 / 2)
+    integer_binary_operation_assertion(:sdiv, 10, 2, 10 / 2)
+    integer_binary_operation_assertion(:urem, 10, 3, 10 % 3)
+    integer_binary_operation_assertion(:srem, 10, 3, 10 % 3)
   end
 
   def test_integer_bitwise_binary_operations
-    integer_binary_operation_assertion(:shl, 2, 3, 16)
-    integer_binary_operation_assertion(:lshr, 16, 3, 2)
-    integer_binary_operation_assertion(:ashr, 16, 3, 2)
-    integer_binary_operation_assertion(:and, 2, 1, 0)
-    integer_binary_operation_assertion(:or, 2, 1, 3)
-    integer_binary_operation_assertion(:xor, 3, 2, 1)
+    integer_binary_operation_assertion(:shl, 2, 3, 2 << 3)
+    integer_binary_operation_assertion(:lshr, 16, 3, 16 >> 3)
+    integer_binary_operation_assertion(:ashr, 16, 3, 16 >> 3)
+    integer_binary_operation_assertion(:and, 2, 1, 2 & 1)
+    integer_binary_operation_assertion(:or, 2, 1, 2 | 1)
+    integer_binary_operation_assertion(:xor, 3, 2, 3 ^ 2)
   end
 
   def test_float_binary_operations
-    float_binary_operation_assertion(:fadd, 3.1, 2.2, 5.30)
-    float_binary_operation_assertion(:fsub, 3.1, 2.2, 0.90)
-    float_binary_operation_assertion(:fmul, 3.1, 2.2, 6.82)
-    float_binary_operation_assertion(:fdiv, 3.1, 2.2, 1.41)
-    float_binary_operation_assertion(:frem, 3.1, 2.2, 0.90)
+    float_binary_operation_assertion(:fadd, 3.1, 2.2, 3.1 + 2.2)
+    float_binary_operation_assertion(:fsub, 3.1, 2.2, 3.1 - 2.2)
+    float_binary_operation_assertion(:fmul, 3.1, 2.2, 3.1 * 2.2)
+    float_binary_operation_assertion(:fdiv, 3.1, 2.2, 3.1 / 2.2)
+    float_binary_operation_assertion(:frem, 3.1, 2.2, 3.1 % 2.2)
   end
 
   def integer_binary_operation_assertion(operation, operand1, operand2, expected_result)

--- a/test/binary_operations_test.rb
+++ b/test/binary_operations_test.rb
@@ -7,48 +7,48 @@ class BasicOperationsTestCase < Test::Unit::TestCase
   end
 
   def test_integer_binary_operations
-    define_integer_binary_operation_assertion(:add, 3, 2, 5)
-    define_integer_binary_operation_assertion(:sub, 3, 2, 1)
-    define_integer_binary_operation_assertion(:mul, 3, 2, 6)
-    define_integer_binary_operation_assertion(:udiv, 10, 2, 5)
-    define_integer_binary_operation_assertion(:sdiv, 10, 2, 5)
-    define_integer_binary_operation_assertion(:urem, 10, 3, 1)
-    define_integer_binary_operation_assertion(:srem, 10, 3, 1)
+    integer_binary_operation_assertion(:add, 3, 2, 5)
+    integer_binary_operation_assertion(:sub, 3, 2, 1)
+    integer_binary_operation_assertion(:mul, 3, 2, 6)
+    integer_binary_operation_assertion(:udiv, 10, 2, 5)
+    integer_binary_operation_assertion(:sdiv, 10, 2, 5)
+    integer_binary_operation_assertion(:urem, 10, 3, 1)
+    integer_binary_operation_assertion(:srem, 10, 3, 1)
   end
 
   def test_integer_bitwise_binary_operations
-    define_integer_binary_operation_assertion(:shl, 2, 3, 16)
-    define_integer_binary_operation_assertion(:lshr, 16, 3, 2)
-    define_integer_binary_operation_assertion(:ashr, 16, 3, 2)
-    define_integer_binary_operation_assertion(:and, 2, 1, 0)
-    define_integer_binary_operation_assertion(:or, 2, 1, 3)
-    define_integer_binary_operation_assertion(:xor, 3, 2, 1)
+    integer_binary_operation_assertion(:shl, 2, 3, 16)
+    integer_binary_operation_assertion(:lshr, 16, 3, 2)
+    integer_binary_operation_assertion(:ashr, 16, 3, 2)
+    integer_binary_operation_assertion(:and, 2, 1, 0)
+    integer_binary_operation_assertion(:or, 2, 1, 3)
+    integer_binary_operation_assertion(:xor, 3, 2, 1)
   end
 
   def test_float_binary_operations
-    define_float_binary_operation_assertion(:fadd, 3.1, 2.2, 5.30)
-    define_float_binary_operation_assertion(:fsub, 3.1, 2.2, 0.90)
-    define_float_binary_operation_assertion(:fmul, 3.1, 2.2, 6.82)
-    define_float_binary_operation_assertion(:fdiv, 3.1, 2.2, 1.41)
-    define_float_binary_operation_assertion(:frem, 3.1, 2.2, 0.90)
+    float_binary_operation_assertion(:fadd, 3.1, 2.2, 5.30)
+    float_binary_operation_assertion(:fsub, 3.1, 2.2, 0.90)
+    float_binary_operation_assertion(:fmul, 3.1, 2.2, 6.82)
+    float_binary_operation_assertion(:fdiv, 3.1, 2.2, 1.41)
+    float_binary_operation_assertion(:frem, 3.1, 2.2, 0.90)
   end
 
-  def define_integer_binary_operation_assertion(operation, operand1, operand2, expected_result)
-    result = define_binary_operation(operation,
-                                     LLVM::Int(operand1), LLVM::Int(operand2),
-                                     LLVM::Int).to_i
+  def integer_binary_operation_assertion(operation, operand1, operand2, expected_result)
+    result = run_binary_operation(operation,
+                                  LLVM::Int(operand1), LLVM::Int(operand2),
+                                  LLVM::Int).to_i
     assert_equal expected_result, result
   end
 
-  def define_float_binary_operation_assertion(operation, operand1, operand2, expected_result)
-    result = define_binary_operation(operation,
-                                     LLVM::Float(operand1), LLVM::Float(operand2),
-                                     LLVM::Float).to_f
+  def float_binary_operation_assertion(operation, operand1, operand2, expected_result)
+    result = run_binary_operation(operation,
+                                  LLVM::Float(operand1), LLVM::Float(operand2),
+                                  LLVM::Float).to_f
     assert_in_delta expected_result, result, 0.001
   end
 
-  def define_binary_operation(operation, operand1, operand2, return_type)
-    define_function([], [], return_type) do |builder, function, *arguments|
+  def run_binary_operation(operation, operand1, operand2, return_type)
+    run_function([], [], return_type) do |builder, function, *arguments|
       entry = function.basic_blocks.append
       builder.position_at_end(entry)
       builder.ret(builder.send(operation, operand1, operand2))

--- a/test/binary_operations_test.rb
+++ b/test/binary_operations_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class BasicOperationsTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_integer_binary_operations
+    define_integer_binary_operation_assertion(:add, 3, 2, 5)
+    define_integer_binary_operation_assertion(:sub, 3, 2, 1)
+    define_integer_binary_operation_assertion(:mul, 3, 2, 6)
+    define_integer_binary_operation_assertion(:udiv, 10, 2, 5)
+    define_integer_binary_operation_assertion(:sdiv, 10, 2, 5)
+    define_integer_binary_operation_assertion(:urem, 10, 3, 1)
+    define_integer_binary_operation_assertion(:srem, 10, 3, 1)
+  end
+
+  def test_integer_bitwise_binary_operations
+    define_integer_binary_operation_assertion(:shl, 2, 3, 16)
+    define_integer_binary_operation_assertion(:lshr, 16, 3, 2)
+    define_integer_binary_operation_assertion(:ashr, 16, 3, 2)
+    define_integer_binary_operation_assertion(:and, 2, 1, 0)
+    define_integer_binary_operation_assertion(:or, 2, 1, 3)
+    define_integer_binary_operation_assertion(:xor, 3, 2, 1)
+  end
+
+  def test_float_binary_operations
+    define_float_binary_operation_assertion(:fadd, 3.1, 2.2, 5.30)
+    define_float_binary_operation_assertion(:fsub, 3.1, 2.2, 0.90)
+    define_float_binary_operation_assertion(:fmul, 3.1, 2.2, 6.82)
+    define_float_binary_operation_assertion(:fdiv, 3.1, 2.2, 1.41)
+    define_float_binary_operation_assertion(:frem, 3.1, 2.2, 0.90)
+  end
+
+  def define_integer_binary_operation_assertion(operation, operand1, operand2, expected_result)
+    result = define_binary_operation(operation,
+                                     LLVM::Int(operand1), LLVM::Int(operand2),
+                                     LLVM::Int).to_i
+    assert_equal expected_result, result
+  end
+
+  def define_float_binary_operation_assertion(operation, operand1, operand2, expected_result)
+    result = define_binary_operation(operation,
+                                     LLVM::Float(operand1), LLVM::Float(operand2),
+                                     LLVM::Float).to_f
+    assert_in_delta expected_result, result, 0.001
+  end
+
+  def define_binary_operation(operation, operand1, operand2, return_type)
+    define_function([], [], return_type) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      builder.ret(builder.send(operation, operand1, operand2))
+    end
+  end
+
+end

--- a/test/branch_test.rb
+++ b/test/branch_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class BranchTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_branching
+    assert_equal 0, direct_jump_function().to_i
+    assert_equal 0, conditional_jump_function().to_i
+    assert_equal 0, switched_jump_function().to_i
+  end
+
+  def direct_jump_function
+    define_function([], [], LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      branch_1 = function.basic_blocks.append
+      branch_2 = function.basic_blocks.append
+      builder.position_at_end(entry)
+      builder.br(branch_2)
+      builder.position_at_end(branch_1)
+      builder.ret(LLVM::Int(1))
+      builder.position_at_end(branch_2)
+      builder.ret(LLVM::Int(0))
+    end
+  end
+
+  def conditional_jump_function
+    define_function([], [], LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      branch_1 = function.basic_blocks.append
+      branch_2 = function.basic_blocks.append
+      builder.position_at_end(entry)
+      builder.cond(builder.icmp(:eq, LLVM::Int(1), LLVM::Int(2)), branch_1, branch_2)
+      builder.position_at_end(branch_1)
+      builder.ret(LLVM::Int(1))
+      builder.position_at_end(branch_2)
+      builder.ret(LLVM::Int(0))
+    end
+  end
+
+  def switched_jump_function
+    define_function([], [], LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      branch_1 = function.basic_blocks.append
+      branch_2 = function.basic_blocks.append
+      builder.position_at_end(entry)
+      switch = builder.switch(LLVM::Int(1), branch_1, 1)
+      switch.add_case(LLVM::Int(1), branch_2)
+      builder.position_at_end(branch_1)
+      builder.ret(LLVM::Int(1))
+      builder.position_at_end(branch_2)
+      builder.ret(LLVM::Int(0))
+    end
+  end
+
+end

--- a/test/branch_test.rb
+++ b/test/branch_test.rb
@@ -13,7 +13,7 @@ class BranchTestCase < Test::Unit::TestCase
   end
 
   def direct_jump_function
-    define_function([], [], LLVM::Int) do |builder, function, *arguments|
+    run_function([], [], LLVM::Int) do |builder, function, *arguments|
       entry = function.basic_blocks.append
       branch_1 = function.basic_blocks.append
       branch_2 = function.basic_blocks.append
@@ -27,7 +27,7 @@ class BranchTestCase < Test::Unit::TestCase
   end
 
   def conditional_jump_function
-    define_function([], [], LLVM::Int) do |builder, function, *arguments|
+    run_function([], [], LLVM::Int) do |builder, function, *arguments|
       entry = function.basic_blocks.append
       branch_1 = function.basic_blocks.append
       branch_2 = function.basic_blocks.append
@@ -41,7 +41,7 @@ class BranchTestCase < Test::Unit::TestCase
   end
 
   def switched_jump_function
-    define_function([], [], LLVM::Int) do |builder, function, *arguments|
+    run_function([], [], LLVM::Int) do |builder, function, *arguments|
       entry = function.basic_blocks.append
       branch_1 = function.basic_blocks.append
       branch_2 = function.basic_blocks.append

--- a/test/call_test.rb
+++ b/test/call_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class CallTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_simple_call
+    test_module = define_module("test_module") do |host_module|
+      define_function(host_module, "test_function", [], LLVM::Int) do |builder, function, *arguments|
+        entry = function.basic_blocks.append
+        builder.position_at_end(entry)
+        builder.ret(LLVM::Int(1))
+      end
+    end
+    assert_equal 1, run_function_on_module(test_module, "test_function").to_i
+  end
+
+  def test_nested_call
+    test_module = define_module("test_module") do |host_module|
+      function_1 = define_function(host_module, "test_function_1", [], LLVM::Int) do |builder, function, *arguments|
+        entry = function.basic_blocks.append
+        builder.position_at_end(entry)
+        builder.ret(LLVM::Int(1))
+      end
+      function_2 = define_function(host_module, "test_function_2", [], LLVM::Int) do |builder, function, *arguments|
+        entry = function.basic_blocks.append
+        builder.position_at_end(entry)
+        builder.ret(builder.call(function_1))
+      end
+    end
+    assert_equal 1, run_function_on_module(test_module, "test_function_2").to_i
+  end
+
+  def test_recursive_call
+    test_module = define_module("test_module") do |host_module|
+      define_function(host_module, "test_function", [LLVM::Int], LLVM::Int) do |builder, function, *arguments|
+        entry = function.basic_blocks.append
+        recurse = function.basic_blocks.append
+        exit = function.basic_blocks.append
+        builder.position_at_end(entry)
+        builder.cond(builder.icmp(:uge, arguments.first, LLVM::Int(5)), exit, recurse)
+        builder.position_at_end(recurse)
+        result = builder.call(function, builder.add(arguments.first, LLVM::Int(1)))
+        builder.br(exit)
+        builder.position_at_end(exit)
+        builder.ret(builder.phi(LLVM::Int, arguments.first, entry, result, recurse))
+      end
+    end
+    assert_equal 5, run_function_on_module(test_module, "test_function", 1).to_i
+  end
+
+end

--- a/test/call_test.rb
+++ b/test/call_test.rb
@@ -51,4 +51,16 @@ class CallTestCase < Test::Unit::TestCase
     assert_equal 5, run_function_on_module(test_module, "test_function", 1).to_i
   end
 
+  def test_external
+    test_module = define_module("test_module") do |host_module|
+      external = host_module.functions.add("abs", [LLVM::Int32], LLVM::Int32)
+      define_function(host_module, "test_function", [LLVM::Int32], LLVM::Int32) do |builder, function, *arguments|
+        entry = function.basic_blocks.append
+        builder.position_at_end(entry)
+        builder.ret(builder.call(external, arguments.first))
+      end
+    end
+    assert_equal -10.abs, run_function_on_module(test_module, "test_function", -10).to_i
+  end
+
 end

--- a/test/comparisons_test.rb
+++ b/test/comparisons_test.rb
@@ -2,12 +2,6 @@ require "test_helper"
 
 class ComparisonsTestCase < Test::Unit::TestCase
 
-  LLVM_SIGNED = true
-  LLVM_UNSIGNED = false
-
-  LLVM_FALSE = 0
-  LLVM_TRUE = 1
-
   def setup
     LLVM.init_x86
   end

--- a/test/comparisons_test.rb
+++ b/test/comparisons_test.rb
@@ -2,38 +2,44 @@ require "test_helper"
 
 class ComparisonsTestCase < Test::Unit::TestCase
 
+  LLVM_SIGNED = true
+  LLVM_UNSIGNED = false
+
+  LLVM_FALSE = 0
+  LLVM_TRUE = 1
+
   def setup
     LLVM.init_x86
   end
 
   def test_integer_comparison
-    integer_comparison_assertion(:eq, 1, 1, true, 1)
-    integer_comparison_assertion(:ne, 1, 1, true, 0)
-    integer_comparison_assertion(:ugt, 2, 2, false, 0)
-    integer_comparison_assertion(:uge, 2, 1, false, 1)
-    integer_comparison_assertion(:ult, 1, 1, false, 0)
-    integer_comparison_assertion(:ule, 1, 2, false, 1)
-    integer_comparison_assertion(:sgt, -2, 2, true, 0)
-    integer_comparison_assertion(:sge, -2, 1, true, 0)
-    integer_comparison_assertion(:slt, -1, 2, true, 1)
-    integer_comparison_assertion(:sle, -1, 2, true, 1)
+    integer_comparison_assertion(:eq, 1, 1, LLVM_SIGNED, LLVM_TRUE)
+    integer_comparison_assertion(:ne, 1, 1, LLVM_SIGNED, LLVM_FALSE)
+    integer_comparison_assertion(:ugt, 2, 2, LLVM_UNSIGNED, LLVM_FALSE)
+    integer_comparison_assertion(:uge, 2, 1, LLVM_UNSIGNED, LLVM_TRUE)
+    integer_comparison_assertion(:ult, 1, 1, LLVM_UNSIGNED, LLVM_FALSE)
+    integer_comparison_assertion(:ule, 1, 2, LLVM_UNSIGNED, LLVM_TRUE)
+    integer_comparison_assertion(:sgt, -2, 2, LLVM_SIGNED, LLVM_FALSE)
+    integer_comparison_assertion(:sge, -2, 1, LLVM_SIGNED, LLVM_FALSE)
+    integer_comparison_assertion(:slt, -1, 2, LLVM_SIGNED, LLVM_TRUE)
+    integer_comparison_assertion(:sle, -1, 2, LLVM_SIGNED, LLVM_TRUE)
   end
 
   def test_float_comparison
-    float_comparison_assertion(:oeq, 1.0, 1.0, 1)
-    float_comparison_assertion(:one, 1.0, 1.0, 0)
-    float_comparison_assertion(:ogt, 2.0, 2.0, 0)
-    float_comparison_assertion(:oge, 2.0, 1.0, 1)
-    float_comparison_assertion(:olt, 1.0, 1.0, 0)
-    float_comparison_assertion(:ole, 1.0, 2.0, 1)
-    float_comparison_assertion(:ord, 1.0, 2.0, 1)
-    float_comparison_assertion(:ueq, 1.0, 1.0, 1)
-    float_comparison_assertion(:une, 1.0, 1.0, 0)
-    float_comparison_assertion(:ugt, 2.0, 2.0, 0)
-    float_comparison_assertion(:uge, 2.0, 1.0, 1)
-    float_comparison_assertion(:ult, 1.0, 1.0, 0)
-    float_comparison_assertion(:ule, 1.0, 2.0, 1)
-    float_comparison_assertion(:uno, 1.0, 2.0, 0)
+    float_comparison_assertion(:oeq, 1.0, 1.0, LLVM_TRUE)
+    float_comparison_assertion(:one, 1.0, 1.0, LLVM_FALSE)
+    float_comparison_assertion(:ogt, 2.0, 2.0, LLVM_FALSE)
+    float_comparison_assertion(:oge, 2.0, 1.0, LLVM_TRUE)
+    float_comparison_assertion(:olt, 1.0, 1.0, LLVM_FALSE)
+    float_comparison_assertion(:ole, 1.0, 2.0, LLVM_TRUE)
+    float_comparison_assertion(:ord, 1.0, 2.0, LLVM_TRUE)
+    float_comparison_assertion(:ueq, 1.0, 1.0, LLVM_TRUE)
+    float_comparison_assertion(:une, 1.0, 1.0, LLVM_FALSE)
+    float_comparison_assertion(:ugt, 2.0, 2.0, LLVM_FALSE)
+    float_comparison_assertion(:uge, 2.0, 1.0, LLVM_TRUE)
+    float_comparison_assertion(:ult, 1.0, 1.0, LLVM_FALSE)
+    float_comparison_assertion(:ule, 1.0, 2.0, LLVM_TRUE)
+    float_comparison_assertion(:uno, 1.0, 2.0, LLVM_FALSE)
   end
 
   def integer_comparison_assertion(operation, operand1, operand2, signed, expected_result)

--- a/test/comparisons_test.rb
+++ b/test/comparisons_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class ComparisonsTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_integer_comparison
+    define_integer_comparison_assertion(:eq, 1, 1, true, 1)
+    define_integer_comparison_assertion(:ne, 1, 1, true, 0)
+    define_integer_comparison_assertion(:ugt, 2, 2, false, 0)
+    define_integer_comparison_assertion(:uge, 2, 1, false, 1)
+    define_integer_comparison_assertion(:ult, 1, 1, false, 0)
+    define_integer_comparison_assertion(:ule, 1, 2, false, 1)
+    define_integer_comparison_assertion(:sgt, -2, 2, true, 0)
+    define_integer_comparison_assertion(:sge, -2, 1, true, 0)
+    define_integer_comparison_assertion(:slt, -1, 2, true, 1)
+    define_integer_comparison_assertion(:sle, -1, 2, true, 1)
+  end
+
+  def test_float_comparison
+    define_float_comparison_assertion(:oeq, 1.0, 1.0, 1)
+    define_float_comparison_assertion(:one, 1.0, 1.0, 0)
+    define_float_comparison_assertion(:ogt, 2.0, 2.0, 0)
+    define_float_comparison_assertion(:oge, 2.0, 1.0, 1)
+    define_float_comparison_assertion(:olt, 1.0, 1.0, 0)
+    define_float_comparison_assertion(:ole, 1.0, 2.0, 1)
+    define_float_comparison_assertion(:ord, 1.0, 2.0, 1)
+    define_float_comparison_assertion(:ueq, 1.0, 1.0, 1)
+    define_float_comparison_assertion(:une, 1.0, 1.0, 0)
+    define_float_comparison_assertion(:ugt, 2.0, 2.0, 0)
+    define_float_comparison_assertion(:uge, 2.0, 1.0, 1)
+    define_float_comparison_assertion(:ult, 1.0, 1.0, 0)
+    define_float_comparison_assertion(:ule, 1.0, 2.0, 1)
+    define_float_comparison_assertion(:uno, 1.0, 2.0, 0)
+  end
+
+  def define_integer_comparison_assertion(operation, operand1, operand2, signed, expected_result)
+    result = define_comparison_operation(:icmp,
+                                         operation,
+                                         LLVM::Int.from_i(operand1, signed),
+                                         LLVM::Int.from_i(operand2, signed),
+                                         LLVM::Int1).to_i(false)
+    assert_equal expected_result, result
+  end
+
+  def define_float_comparison_assertion(operation, operand1, operand2, expected_result)
+    result = define_comparison_operation(:fcmp,
+                                         operation,
+                                         LLVM::Float(operand1),
+                                         LLVM::Float(operand2),
+                                         LLVM::Int1).to_i(false)
+    assert_equal expected_result, result
+  end
+
+  def define_comparison_operation(comparison_operation, comparison_operator,
+                                  operand1, operand2, return_type)
+    define_function([], [], return_type) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      builder.ret(builder.send(comparison_operation, comparison_operator, operand1, operand2))
+    end
+  end
+
+end

--- a/test/comparisons_test.rb
+++ b/test/comparisons_test.rb
@@ -7,56 +7,56 @@ class ComparisonsTestCase < Test::Unit::TestCase
   end
 
   def test_integer_comparison
-    define_integer_comparison_assertion(:eq, 1, 1, true, 1)
-    define_integer_comparison_assertion(:ne, 1, 1, true, 0)
-    define_integer_comparison_assertion(:ugt, 2, 2, false, 0)
-    define_integer_comparison_assertion(:uge, 2, 1, false, 1)
-    define_integer_comparison_assertion(:ult, 1, 1, false, 0)
-    define_integer_comparison_assertion(:ule, 1, 2, false, 1)
-    define_integer_comparison_assertion(:sgt, -2, 2, true, 0)
-    define_integer_comparison_assertion(:sge, -2, 1, true, 0)
-    define_integer_comparison_assertion(:slt, -1, 2, true, 1)
-    define_integer_comparison_assertion(:sle, -1, 2, true, 1)
+    integer_comparison_assertion(:eq, 1, 1, true, 1)
+    integer_comparison_assertion(:ne, 1, 1, true, 0)
+    integer_comparison_assertion(:ugt, 2, 2, false, 0)
+    integer_comparison_assertion(:uge, 2, 1, false, 1)
+    integer_comparison_assertion(:ult, 1, 1, false, 0)
+    integer_comparison_assertion(:ule, 1, 2, false, 1)
+    integer_comparison_assertion(:sgt, -2, 2, true, 0)
+    integer_comparison_assertion(:sge, -2, 1, true, 0)
+    integer_comparison_assertion(:slt, -1, 2, true, 1)
+    integer_comparison_assertion(:sle, -1, 2, true, 1)
   end
 
   def test_float_comparison
-    define_float_comparison_assertion(:oeq, 1.0, 1.0, 1)
-    define_float_comparison_assertion(:one, 1.0, 1.0, 0)
-    define_float_comparison_assertion(:ogt, 2.0, 2.0, 0)
-    define_float_comparison_assertion(:oge, 2.0, 1.0, 1)
-    define_float_comparison_assertion(:olt, 1.0, 1.0, 0)
-    define_float_comparison_assertion(:ole, 1.0, 2.0, 1)
-    define_float_comparison_assertion(:ord, 1.0, 2.0, 1)
-    define_float_comparison_assertion(:ueq, 1.0, 1.0, 1)
-    define_float_comparison_assertion(:une, 1.0, 1.0, 0)
-    define_float_comparison_assertion(:ugt, 2.0, 2.0, 0)
-    define_float_comparison_assertion(:uge, 2.0, 1.0, 1)
-    define_float_comparison_assertion(:ult, 1.0, 1.0, 0)
-    define_float_comparison_assertion(:ule, 1.0, 2.0, 1)
-    define_float_comparison_assertion(:uno, 1.0, 2.0, 0)
+    float_comparison_assertion(:oeq, 1.0, 1.0, 1)
+    float_comparison_assertion(:one, 1.0, 1.0, 0)
+    float_comparison_assertion(:ogt, 2.0, 2.0, 0)
+    float_comparison_assertion(:oge, 2.0, 1.0, 1)
+    float_comparison_assertion(:olt, 1.0, 1.0, 0)
+    float_comparison_assertion(:ole, 1.0, 2.0, 1)
+    float_comparison_assertion(:ord, 1.0, 2.0, 1)
+    float_comparison_assertion(:ueq, 1.0, 1.0, 1)
+    float_comparison_assertion(:une, 1.0, 1.0, 0)
+    float_comparison_assertion(:ugt, 2.0, 2.0, 0)
+    float_comparison_assertion(:uge, 2.0, 1.0, 1)
+    float_comparison_assertion(:ult, 1.0, 1.0, 0)
+    float_comparison_assertion(:ule, 1.0, 2.0, 1)
+    float_comparison_assertion(:uno, 1.0, 2.0, 0)
   end
 
-  def define_integer_comparison_assertion(operation, operand1, operand2, signed, expected_result)
-    result = define_comparison_operation(:icmp,
-                                         operation,
-                                         LLVM::Int.from_i(operand1, signed),
-                                         LLVM::Int.from_i(operand2, signed),
-                                         LLVM::Int1).to_i(false)
+  def integer_comparison_assertion(operation, operand1, operand2, signed, expected_result)
+    result = run_comparison_operation(:icmp,
+                                      operation,
+                                      LLVM::Int.from_i(operand1, signed),
+                                      LLVM::Int.from_i(operand2, signed),
+                                      LLVM::Int1).to_i(false)
     assert_equal expected_result, result
   end
 
-  def define_float_comparison_assertion(operation, operand1, operand2, expected_result)
-    result = define_comparison_operation(:fcmp,
-                                         operation,
-                                         LLVM::Float(operand1),
-                                         LLVM::Float(operand2),
-                                         LLVM::Int1).to_i(false)
+  def float_comparison_assertion(operation, operand1, operand2, expected_result)
+    result = run_comparison_operation(:fcmp,
+                                      operation,
+                                      LLVM::Float(operand1),
+                                      LLVM::Float(operand2),
+                                      LLVM::Int1).to_i(false)
     assert_equal expected_result, result
   end
 
-  def define_comparison_operation(comparison_operation, comparison_operator,
-                                  operand1, operand2, return_type)
-    define_function([], [], return_type) do |builder, function, *arguments|
+  def run_comparison_operation(comparison_operation, comparison_operator,
+                               operand1, operand2, return_type)
+    run_function([], [], return_type) do |builder, function, *arguments|
       entry = function.basic_blocks.append
       builder.position_at_end(entry)
       builder.ret(builder.send(comparison_operation, comparison_operator, operand1, operand2))

--- a/test/conversions_test.rb
+++ b/test/conversions_test.rb
@@ -1,0 +1,86 @@
+require "test_helper"
+
+class ConversionsTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_trunc_to
+    integer_conversion_assertion(:trunc, LLVM::Int32.from_i(257), LLVM::Int8, LLVM_UNSIGNED, 1)
+    integer_conversion_assertion(:trunc, LLVM::Int32.from_i(123), LLVM::Int1, LLVM_UNSIGNED, 1)
+    integer_conversion_assertion(:trunc, LLVM::Int32.from_i(122), LLVM::Int1, LLVM_UNSIGNED, 0)
+  end
+
+  def test_zext_to
+    integer_conversion_assertion(:zext, LLVM::Int16.from_i(257), LLVM::Int32, LLVM_UNSIGNED, 257)
+  end
+
+  def test_sext_to
+    integer_conversion_assertion(:sext, LLVM::Int1.from_i(1), LLVM::Int32, LLVM_SIGNED, -1)
+    integer_conversion_assertion(:sext, LLVM::Int8.from_i(-1), LLVM::Int16, LLVM_UNSIGNED, 65535)
+  end
+
+  def test_fptrunc_to
+    float_conversion_assertion(:fp_trunc, LLVM::Double(123.0), LLVM::Float, 123.0)
+  end
+
+  def test_fpext_to
+    float_conversion_assertion(:fp_ext, LLVM::Float(123.0), LLVM::Double, 123.0)
+    float_conversion_assertion(:fp_ext, LLVM::Float(123.0), LLVM::Float, 123.0)
+  end
+
+  def test_fptoui_to
+    different_type_assertion(:fp2ui, LLVM::Double(123.3), LLVM::Int32, :integer, 123)
+    different_type_assertion(:fp2ui, LLVM::Double(0.7), LLVM::Int32, :integer, 0)
+    different_type_assertion(:fp2ui, LLVM::Double(1.7), LLVM::Int32, :integer, 1)
+  end
+
+  def test_fptosi_to
+    different_type_assertion(:fp2si, LLVM::Double(-123.3), LLVM::Int32, :integer, -123)
+    different_type_assertion(:fp2si, LLVM::Double(0.7), LLVM::Int32, :integer, 0)
+    different_type_assertion(:fp2si, LLVM::Double(1.7), LLVM::Int32, :integer, 1)
+  end
+
+  def test_uitofp_to
+    different_type_assertion(:ui2fp, LLVM::Int32.from_i(257), LLVM::Float, :float, 257.0)
+    different_type_assertion(:ui2fp, LLVM::Int8.from_i(-1), LLVM::Double, :float, 255.0)
+  end
+
+  def test_sitofp_to
+    different_type_assertion(:si2fp, LLVM::Int32.from_i(257), LLVM::Float, :float, 257.0)
+    different_type_assertion(:si2fp, LLVM::Int8.from_i(-1), LLVM::Double, :float, -1.0)
+  end
+
+  def test_bitcast_to
+    different_type_assertion(:bit_cast, LLVM::Int8.from_i(255), LLVM::Int8, :integer, -1)
+  end
+
+  def integer_conversion_assertion(operation, operand, return_type, signed, expected_result)
+    result = run_conversion_operation(operation, operand, return_type)
+    assert_equal expected_result, result.to_i(signed)
+  end
+
+  def float_conversion_assertion(operation, operand, return_type, expected_result)
+    result = run_conversion_operation(operation, operand, return_type)
+    assert_in_delta expected_result, result.to_f(return_type), 0.001
+  end
+
+  def different_type_assertion(operation, operand, return_type, assertion_type, expected_result)
+    result = run_conversion_operation(operation, operand, return_type)
+    if assertion_type == :integer
+      assert_equal expected_result, result.to_i
+    else
+      assert_in_delta expected_result, result.to_f(return_type), 0.001
+    end
+  end
+
+  def run_conversion_operation(operation, operand, return_type)
+    run_function([], [], return_type) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      builder.ret(builder.send(operation, operand, return_type))
+    end
+  end
+
+end

--- a/test/equality_test.rb
+++ b/test/equality_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+require "llvm/core"
+
+class EqualityTestCase < Test::Unit::TestCase
+
+	def setup
+    LLVM.init_x86
+	end
+
+	def test_module
+		mod = LLVM::Module.create('test')
+		assert_equal mod, mod
+		assert_equal mod, LLVM::Module.from_ptr(mod.to_ptr)
+	end
+
+	def test_type
+    type = LLVM::Float.type
+		assert_equal type, type
+		assert_equal type, LLVM::Float.type
+	end
+
+	def test_function
+		mod = LLVM::Module.create('test')
+		fn = mod.functions.add('test', LLVM.Void)
+		assert_equal fn, fn
+		assert_equal fn, mod.functions.named('test')
+	end
+
+end
+

--- a/test/equality_test.rb
+++ b/test/equality_test.rb
@@ -7,23 +7,85 @@ class EqualityTestCase < Test::Unit::TestCase
     LLVM.init_x86
 	end
 
+  class MyModule < LLVM::Module; end
+  class MyInt < LLVM::Int32; end
+  class MyType < LLVM::Type; end
+  class MyFunction < LLVM::Function; end
+
+  def assert_equalities(options)
+    map = {
+      :equal     => method(:assert_equal),
+      :not_equal => method(:assert_not_equal),
+      :same      => method(:assert_same),
+      :not_same  => method(:assert_not_same),
+      :eql       => lambda {|n, m, name| assert n.eql?(m), name },
+      :not_eql   => lambda {|n, m, name| assert !n.eql?(m), name },
+    }
+
+    map.each do |name, callable|
+      options[name].combination(2).each do |n, m|
+        callable.call(n, m, name.to_s)
+      end
+    end
+
+  end
+
+  def test_int_value
+    int1 = LLVM::Int32.from_i(1)
+    int2 = LLVM::Int32.from_ptr(int1.to_ptr)
+    int3 = LLVM::Int32.from_i(2)
+    int4 = MyInt.from_ptr(int1.to_ptr)
+
+    assert_equalities :equal     => [int1, int2, int4],
+                      :not_equal => [int1, int3],
+                      :same      => [int1, int1],
+                      :not_same  => [int1, int2, int3, int4],
+                      :eql       => [int1, int2],
+                      :not_eql   => [int1, int3, int4]
+  end
+
 	def test_module
-		mod = LLVM::Module.create('test')
-		assert_equal mod, mod
-		assert_equal mod, LLVM::Module.from_ptr(mod.to_ptr)
+		mod1 = LLVM::Module.create('test')
+    mod2 = LLVM::Module.from_ptr(mod1.to_ptr)
+		mod3 = LLVM::Module.create('dummy')
+    mod4 = MyModule.from_ptr(mod1.to_ptr)
+
+    assert_equalities :equal     => [mod1, mod2, mod4],
+                      :not_equal => [mod1, mod3],
+                      :same      => [mod1, mod1],
+                      :not_same  => [mod1, mod2, mod3, mod4],
+                      :eql       => [mod1, mod2],
+                      :not_eql   => [mod1, mod3, mod4]
 	end
 
 	def test_type
-    type = LLVM::Float.type
-		assert_equal type, type
-		assert_equal type, LLVM::Float.type
+    type1 = LLVM::Float.type
+    type2 = LLVM::Type.from_ptr(type1.to_ptr)
+    type3 = LLVM::Double.type
+    type4 = MyType.from_ptr(type1.to_ptr)
+
+    assert_equalities :equal     => [type1, type2, type4],
+                      :not_equal => [type1, type3],
+                      :same      => [type1, type1],
+                      :not_same  => [type1, type2, type3, type4],
+                      :eql       => [type1, type2],
+                      :not_eql   => [type1, type3, type4]
 	end
 
 	def test_function
 		mod = LLVM::Module.create('test')
-		fn = mod.functions.add('test', LLVM.Void)
-		assert_equal fn, fn
-		assert_equal fn, mod.functions.named('test')
+
+		fn1 = mod.functions.add('test1', LLVM.Void)
+    fn2 = LLVM::Function.from_ptr(fn1.to_ptr)
+		fn3 = mod.functions.add('test2', LLVM.Void)
+    fn4 = MyFunction.from_ptr(fn1.to_ptr)
+
+    assert_equalities :equal     => [fn1, fn2, fn4],
+                      :not_equal => [fn1, fn3],
+                      :same      => [fn1, fn1],
+                      :not_same  => [fn1, fn2, fn3, fn4],
+                      :eql       => [fn1, fn2],
+                      :not_eql   => [fn1, fn3, fn4]
 	end
 
 end

--- a/test/equality_test.rb
+++ b/test/equality_test.rb
@@ -3,9 +3,9 @@ require "llvm/core"
 
 class EqualityTestCase < Test::Unit::TestCase
 
-	def setup
+  def setup
     LLVM.init_x86
-	end
+  end
 
   class MyModule < LLVM::Module; end
   class MyInt < LLVM::Int32; end
@@ -44,10 +44,10 @@ class EqualityTestCase < Test::Unit::TestCase
                       :not_eql   => [int1, int3, int4]
   end
 
-	def test_module
-		mod1 = LLVM::Module.create('test')
+  def test_module
+    mod1 = LLVM::Module.create('test')
     mod2 = LLVM::Module.from_ptr(mod1.to_ptr)
-		mod3 = LLVM::Module.create('dummy')
+    mod3 = LLVM::Module.create('dummy')
     mod4 = MyModule.from_ptr(mod1.to_ptr)
 
     assert_equalities :equal     => [mod1, mod2, mod4],
@@ -56,9 +56,9 @@ class EqualityTestCase < Test::Unit::TestCase
                       :not_same  => [mod1, mod2, mod3, mod4],
                       :eql       => [mod1, mod2],
                       :not_eql   => [mod1, mod3, mod4]
-	end
+  end
 
-	def test_type
+  def test_type
     type1 = LLVM::Float.type
     type2 = LLVM::Type.from_ptr(type1.to_ptr)
     type3 = LLVM::Double.type
@@ -70,14 +70,14 @@ class EqualityTestCase < Test::Unit::TestCase
                       :not_same  => [type1, type2, type3, type4],
                       :eql       => [type1, type2],
                       :not_eql   => [type1, type3, type4]
-	end
+  end
 
-	def test_function
-		mod = LLVM::Module.create('test')
+  def test_function
+    mod = LLVM::Module.create('test')
 
-		fn1 = mod.functions.add('test1', LLVM.Void)
+    fn1 = mod.functions.add('test1', LLVM.Void)
     fn2 = LLVM::Function.from_ptr(fn1.to_ptr)
-		fn3 = mod.functions.add('test2', LLVM.Void)
+    fn3 = mod.functions.add('test2', LLVM.Void)
     fn4 = MyFunction.from_ptr(fn1.to_ptr)
 
     assert_equalities :equal     => [fn1, fn2, fn4],
@@ -86,7 +86,7 @@ class EqualityTestCase < Test::Unit::TestCase
                       :not_same  => [fn1, fn2, fn3, fn4],
                       :eql       => [fn1, fn2],
                       :not_eql   => [fn1, fn3, fn4]
-	end
+  end
 
 end
 

--- a/test/generic_value_test.rb
+++ b/test/generic_value_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class GenericValueTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_from_it
+    assert_equal 2, LLVM::GenericValue(2).to_i
+    assert_equal 0 ,LLVM::GenericValue(2.2).to_i
+  end
+
+  def test_from_float
+    assert_in_delta 2.2, LLVM::GenericValue(2.2).to_f, 0.01
+  end
+
+end

--- a/test/instruction_test.rb
+++ b/test/instruction_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class InstructionTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+    @module = LLVM::Module.create("InstructionTestCase")
+  end
+
+  def test_instruction
+    fn = @module.functions.add("test_instruction", [LLVM::Double], LLVM::Double) do |fn, arg|
+      fn.basic_blocks.append.build do |builder|
+				builder.ret(
+					builder.fadd(arg, LLVM.Double(3.0)))
+      end
+    end
+
+		entry = fn.basic_blocks.entry
+
+		inst1 = entry.first_instruction
+		inst2 = entry.last_instruction
+
+		assert_kind_of LLVM::Instruction, inst1
+		assert_kind_of LLVM::Instruction, inst2
+
+		assert_equal inst2, inst1.next
+		assert_equal inst1, inst2.previous
+		assert_equal entry, inst1.parent
+		assert_equal entry, inst2.parent
+  end
+
+end
+
+

--- a/test/instruction_test.rb
+++ b/test/instruction_test.rb
@@ -10,23 +10,23 @@ class InstructionTestCase < Test::Unit::TestCase
   def test_instruction
     fn = @module.functions.add("test_instruction", [LLVM::Double], LLVM::Double) do |fn, arg|
       fn.basic_blocks.append.build do |builder|
-				builder.ret(
-					builder.fadd(arg, LLVM.Double(3.0)))
+        builder.ret(
+          builder.fadd(arg, LLVM.Double(3.0)))
       end
     end
 
-		entry = fn.basic_blocks.entry
+    entry = fn.basic_blocks.entry
 
-		inst1 = entry.instructions.first
-		inst2 = entry.instructions.last
+    inst1 = entry.instructions.first
+    inst2 = entry.instructions.last
 
-		assert_kind_of LLVM::Instruction, inst1
-		assert_kind_of LLVM::Instruction, inst2
+    assert_kind_of LLVM::Instruction, inst1
+    assert_kind_of LLVM::Instruction, inst2
 
-		assert_equal inst2, inst1.next
-		assert_equal inst1, inst2.previous
-		assert_equal entry, inst1.parent
-		assert_equal entry, inst2.parent
+    assert_equal inst2, inst1.next
+    assert_equal inst1, inst2.previous
+    assert_equal entry, inst1.parent
+    assert_equal entry, inst2.parent
   end
 
 end

--- a/test/instruction_test.rb
+++ b/test/instruction_test.rb
@@ -17,8 +17,8 @@ class InstructionTestCase < Test::Unit::TestCase
 
 		entry = fn.basic_blocks.entry
 
-		inst1 = entry.first_instruction
-		inst2 = entry.last_instruction
+		inst1 = entry.instructions.first
+		inst2 = entry.instructions.last
 
 		assert_kind_of LLVM::Instruction, inst1
 		assert_kind_of LLVM::Instruction, inst2

--- a/test/ipo_test.rb
+++ b/test/ipo_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+require "llvm/core"
+require 'llvm/transforms/ipo'
+require 'llvm/core/pass_manager'
+
+class IPOTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_gdce
+    mod = LLVM::Module.create('test')
+
+    fn1 = mod.functions.add("fn1", [], LLVM.Void) do |fn|
+      fn.linkage = :internal
+      fn.basic_blocks.append.build do |builder|
+        builder.ret_void
+      end
+    end
+
+    fn2 = mod.functions.add("fn2", [], LLVM.Void) do |fn|
+      fn.linkage = :internal
+      fn.basic_blocks.append.build do |builder|
+        builder.ret_void
+      end
+    end
+
+    main = mod.functions.add("main", [], LLVM.Void) do |fn|
+      fn.basic_blocks.append.build do |builder|
+        builder.call(fn1)
+        builder.ret_void
+      end
+    end
+
+    fns = mod.functions.to_a
+    assert fns.include?(fn1)
+    assert fns.include?(fn2)
+    assert fns.include?(main)
+
+    # optimize
+    engine = LLVM::ExecutionEngine.create_jit_compiler(mod)
+    passm  = LLVM::PassManager.new(engine)
+
+    passm.gdce!
+    passm.do_initialization
+    passm.run(mod)
+    passm.do_finalization
+
+    fns = mod.functions.to_a
+    assert fns.include?(fn1)
+    assert !fns.include?(fn2), 'fn2 should be eliminated'
+    assert fns.include?(main)
+  end
+
+end

--- a/test/memory_access_test.rb
+++ b/test/memory_access_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class MemoryAccessTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_memory_access
+    assert_equal 3, simple_memory_access_function(1, 2).to_i
+    assert_equal 7, array_memory_access_function(3, 4).to_i
+  end
+
+  def simple_memory_access_function(value1, value2)
+    run_function([LLVM::Int, LLVM::Int], [value1, value2], LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      pointer1 = builder.alloca(LLVM::Int)
+      pointer2 = builder.alloca(LLVM::Int)
+      builder.store(arguments.first, pointer1)
+      builder.store(arguments.last, pointer2)
+      builder.ret(builder.add(builder.load(pointer1), builder.load(pointer2)))
+    end
+  end
+
+  def array_memory_access_function(value1, value2)
+    run_function([LLVM::Int, LLVM::Int], [value1, value2], LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      pointer = builder.array_alloca(LLVM::Int, LLVM::Int(2))
+      builder.store(arguments.first, builder.gep(pointer, [LLVM::Int(0)]))
+      builder.store(arguments.last, builder.gep(pointer, [LLVM::Int(1)]))
+      builder.ret(builder.add(builder.load(builder.gep(pointer, [LLVM::Int(0)])),
+                              builder.load(builder.gep(pointer, [LLVM::Int(1)]))))
+    end
+  end
+
+end

--- a/test/memory_access_test.rb
+++ b/test/memory_access_test.rb
@@ -7,8 +7,8 @@ class MemoryAccessTestCase < Test::Unit::TestCase
   end
 
   def test_memory_access
-    assert_equal 3, simple_memory_access_function(1, 2).to_i
-    assert_equal 7, array_memory_access_function(3, 4).to_i
+    assert_equal 1 + 2, simple_memory_access_function(1, 2).to_i
+    assert_equal 3 + 4, array_memory_access_function(3, 4).to_i
   end
 
   def simple_memory_access_function(value1, value2)

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -11,7 +11,7 @@ class ModuleTestCase < Test::Unit::TestCase
   end
 
   def simple_function
-    define_function([], [], LLVM::Int) do |builder, function, *arguments|
+    run_function([], [], LLVM::Int) do |builder, function, *arguments|
       entry = function.basic_blocks.append
       builder.position_at_end(entry)
       builder.ret(LLVM::Int(1))

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class ModuleTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_simple_module
+    assert_equal 1, simple_function().to_i
+  end
+
+  def simple_function
+    define_function([], [], LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      builder.ret(LLVM::Int(1))
+    end
+  end
+
+end

--- a/test/phi_test.rb
+++ b/test/phi_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class PhiTest < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_phi
+    assert_equal 1, run_phi_function(0).to_i
+    assert_equal 0, run_phi_function(1).to_i
+  end
+
+  def run_phi_function(argument)
+    run_function([LLVM::Int], argument, LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      block1 = function.basic_blocks.append
+      block2 = function.basic_blocks.append
+      exit = function.basic_blocks.append
+      builder.position_at_end(entry)
+      builder.cond(builder.icmp(:eq, arguments.first, LLVM::Int(0)), block1, block2)
+      builder.position_at_end(block1)
+      result1 = builder.add(arguments.first, LLVM::Int(1))
+      builder.br(exit)
+      builder.position_at_end(block2)
+      result2 = builder.sub(arguments.first, LLVM::Int(1))
+      builder.br(exit)
+      builder.position_at_end(exit)
+      builder.ret(builder.phi(LLVM::Int, result1, block1, result2, block2))
+    end
+  end
+
+end

--- a/test/select_test.rb
+++ b/test/select_test.rb
@@ -7,8 +7,8 @@ class SelectTestCase < Test::Unit::TestCase
   end
 
   def test_select
-    assert 0, select_function(0).to_i
-    assert 1, select_function(1).to_i
+    assert_equal 0, select_function(1).to_i
+    assert_equal 1, select_function(0).to_i
   end
 
   def select_function(value)

--- a/test/select_test.rb
+++ b/test/select_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class SelectTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_select
+    assert 0, select_function(0).to_i
+    assert 1, select_function(1).to_i
+  end
+
+  def select_function(value)
+    run_function([LLVM::Int1], [value], LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      builder.ret(builder.select(arguments.first, LLVM::Int(0), LLVM::Int(1)))
+    end
+  end
+
+end

--- a/test/struct_test.rb
+++ b/test/struct_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class StructTestCase < Test::Unit::TestCase
+
+  LLVM_UNPACKED = false
+  LLVM_PACKED = true
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_simple_struct
+    struct = LLVM::Struct(LLVM::Int, LLVM::Float)
+    assert_instance_of LLVM::Type, struct
+  end
+
+  def test_unpacked_constant_struct_from_size
+    struct = LLVM::ConstantStruct.const(2, LLVM_UNPACKED) { |i| LLVM::Int(i) }
+    assert_instance_of LLVM::ConstantStruct, struct
+    assert_equal 2, struct.operands.size
+  end
+
+  def test_unpacked_constant_struct_from_struct
+    struct = LLVM::ConstantStruct.const([LLVM::Int(0), LLVM::Int(1)], LLVM_UNPACKED)
+    assert_instance_of LLVM::ConstantStruct, struct
+    assert_equal 2, struct.operands.size
+  end
+
+  def test_packed_constant_struct_from_size
+    struct = LLVM::ConstantStruct.const(2, LLVM_PACKED) { |i| LLVM::Int(i) }
+    assert_instance_of LLVM::ConstantStruct, struct
+    assert_equal 2, struct.operands.size
+  end
+
+  def test_packed_constant_struct_from_struct
+    struct = LLVM::ConstantStruct.const([LLVM::Int(0), LLVM::Int(1)], LLVM_PACKED)
+    assert_instance_of LLVM::ConstantStruct, struct
+    assert_equal 2, struct.operands.size
+  end
+
+  def test_struct_values
+    assert_equal 2 + 3, run_struct_values(2, 3).to_i
+  end
+
+  def test_struct_access
+    assert_in_delta 2 + 3.3, run_struct_access(LLVM::Float, 2, 3.3).to_f, 0.001
+  end
+
+  def run_struct_values(value1, value2)
+    run_function([LLVM::Int, LLVM::Int], [value1, value2], LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      pointer = builder.alloca(LLVM::Struct(LLVM::Int, LLVM::Int))
+      struct = builder.load(pointer)
+      struct = builder.insert_value(struct, arguments.first, 0)
+      struct = builder.insert_value(struct, arguments.last, 1)
+      builder.ret(builder.add(builder.extract_value(struct, 0),
+                              builder.extract_value(struct, 1)))
+    end
+  end
+
+  def run_struct_access(return_type, value1, value2)
+    run_function([LLVM::Int, LLVM::Float], [value1, value2], return_type) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      pointer = builder.alloca(LLVM::Struct(LLVM::Float, LLVM::Struct(LLVM::Int, LLVM::Float), LLVM::Int))
+      builder.store(arguments.first, builder.gep(pointer, [LLVM::Int(0), LLVM::Int32.from_i(1), LLVM::Int32.from_i(0)]))
+      builder.store(arguments.last, builder.gep(pointer, [LLVM::Int(0), LLVM::Int32.from_i(1), LLVM::Int32.from_i(1)]))
+      address1 = builder.gep(pointer, [LLVM::Int(0), LLVM::Int32.from_i(1), LLVM::Int32.from_i(0)])
+      address2 = builder.gep(pointer, [LLVM::Int(0), LLVM::Int32.from_i(1), LLVM::Int32.from_i(1)])
+      builder.ret(builder.fadd(builder.ui2fp(builder.load(address1), LLVM::Float), builder.load(address2)))
+    end
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,7 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+
+require "test/unit"
+
+require "llvm/core"
+require "llvm/execution_engine"
+require "llvm/transforms/scalar"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,18 +6,41 @@ require "llvm/core"
 require "llvm/execution_engine"
 require "llvm/transforms/scalar"
 
-def run_function(argument_types, argument_values, return_type)
+def define_module(module_name)
 
-  test_module = LLVM::Module.create("test_module")
+  new_module = LLVM::Module.create(module_name)
 
-  test_module.functions.add("test_function", argument_types, return_type) do |function, *arguments|
+  yield new_module
+
+  new_module.verify
+
+  new_module
+
+end
+
+def define_function(host_module, function_name, argument_types, return_type)
+
+  host_module.functions.add(function_name, argument_types, return_type) do |function, *arguments|
     yield(LLVM::Builder.create, function, *arguments)
   end
 
-  test_module.verify
+end
 
-  engine = LLVM::ExecutionEngine.create_jit_compiler(test_module)
+def run_function_on_module(host_module, function_name, *argument_values)
 
-  engine.run_function(test_module.functions["test_function"], *argument_values)
+  LLVM::ExecutionEngine.
+    create_jit_compiler(host_module).
+    run_function(host_module.functions[function_name], *argument_values)
 
 end
+
+def run_function(argument_types, argument_values, return_type, &block)
+
+  test_module = define_module("test_module") do |host_module|
+    define_function(host_module, "test_function", argument_types, return_type, &block)
+  end
+
+  run_function_on_module(test_module, "test_function", *argument_values)
+
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 
+require "ruby-debug"
+
 require "test/unit"
 
 require "llvm/core"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,16 @@ require "llvm/core"
 require "llvm/execution_engine"
 require "llvm/transforms/scalar"
 
+class Test::Unit::TestCase
+
+  LLVM_SIGNED = true
+  LLVM_UNSIGNED = false
+
+  LLVM_FALSE = 0
+  LLVM_TRUE = 1
+
+end
+
 def define_module(module_name)
 
   new_module = LLVM::Module.create(module_name)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,3 +5,19 @@ require "test/unit"
 require "llvm/core"
 require "llvm/execution_engine"
 require "llvm/transforms/scalar"
+
+def define_function(argument_types, argument_values, return_type)
+
+  test_module = LLVM::Module.create("test_module")
+
+  test_module.functions.add("test_function", argument_types, return_type) do |function, *arguments|
+    yield(LLVM::Builder.create, function, *arguments)
+  end
+
+  test_module.verify
+
+  engine = LLVM::ExecutionEngine.create_jit_compiler(test_module)
+
+  engine.run_function(test_module.functions["test_function"], *argument_values)
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,10 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 
-require "ruby-debug"
+begin
+  require "ruby-debug"
+rescue LoadError
+  # Ignore ruby-debug is case it's not installed
+end
 
 require "test/unit"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ require "llvm/core"
 require "llvm/execution_engine"
 require "llvm/transforms/scalar"
 
-def define_function(argument_types, argument_values, return_type)
+def run_function(argument_types, argument_values, return_type)
 
   test_module = LLVM::Module.create("test_module")
 

--- a/test/type_test.rb
+++ b/test/type_test.rb
@@ -2,14 +2,14 @@ require "test_helper"
 
 class TypeTestCase < Test::Unit::TestCase
 
-	def test_element_type
-		pointer = LLVM.Pointer(LLVM::Int32.type)	
-		pointee = pointer.element_type
+  def test_element_type
+    pointer = LLVM.Pointer(LLVM::Int32.type)  
+    pointee = pointer.element_type
 
-		assert_equal :pointer, pointer.kind
-		assert_equal :integer, pointee.kind
+    assert_equal :pointer, pointer.kind
+    assert_equal :integer, pointee.kind
 
     assert_nil pointee.element_type
-	end
+  end
 
 end

--- a/test/type_test.rb
+++ b/test/type_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class TypeTestCase < Test::Unit::TestCase
+
+	def test_element_type
+		pointer = LLVM.Pointer(LLVM::Int32.type)	
+		pointee = pointer.element_type
+
+		assert_equal :pointer, pointer.kind
+		assert_equal :integer, pointee.kind
+
+    assert_nil pointee.element_type
+	end
+
+end

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -6,6 +6,24 @@ class VectorTestCase < Test::Unit::TestCase
     LLVM.init_x86
   end
 
+  def test_all_ones_vector
+    assert_raise(NotImplementedError) do
+      LLVM::ConstantVector.all_ones
+    end
+  end
+
+  def test_constant_vector_from_size
+    vector = LLVM::ConstantVector.const(2) { |i| LLVM::Int(i) }
+    assert_instance_of LLVM::ConstantVector, vector
+    assert_equal 2, vector.operands.size
+  end
+
+  def test_constant_vector_from_array
+    vector = LLVM::ConstantVector.const([LLVM::Int(0), LLVM::Int(1)])
+    assert_instance_of LLVM::ConstantVector, vector
+    assert_equal 2, vector.operands.size
+  end
+
   def test_vector_elements
     assert_equal 5, run_vector_elements().to_i
   end

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -25,7 +25,11 @@ class VectorTestCase < Test::Unit::TestCase
   end
 
   def test_vector_elements
-    assert_equal 5, run_vector_elements(2, 3).to_i
+    assert_equal 2 + 3, run_vector_elements(2, 3).to_i
+  end
+
+  def test_vector_shuffle
+    assert_equal 1 + 4, run_vector_shuffle(1, 2, 3, 4).to_i
   end
 
   def run_vector_elements(value1, value2)
@@ -38,6 +42,22 @@ class VectorTestCase < Test::Unit::TestCase
       vector = builder.insert_element(vector, arguments.last, LLVM::Int32.from_i(1))
       builder.ret(builder.add(builder.extract_element(vector, LLVM::Int32.from_i(0)),
                               builder.extract_element(vector, LLVM::Int32.from_i(1))))
+    end
+  end
+
+  def run_vector_shuffle(*values)
+    run_function([LLVM::Int, LLVM::Int, LLVM::Int, LLVM::Int], values, LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      vector1 = builder.load(builder.alloca(LLVM::Vector(LLVM::Int, 2)))
+      vector1 = builder.insert_element(vector1, arguments[0], LLVM::Int32.from_i(0))
+      vector1 = builder.insert_element(vector1, arguments[1], LLVM::Int32.from_i(1))
+      vector2 = builder.load(builder.alloca(LLVM::Vector(LLVM::Int, 2)))
+      vector2 = builder.insert_element(vector2, arguments[2], LLVM::Int32.from_i(0))
+      vector2 = builder.insert_element(vector2, arguments[3], LLVM::Int32.from_i(1))
+      vector3 = builder.shuffle_vector(vector1, vector2, LLVM::ConstantVector.const([LLVM::Int(0), LLVM::Int(3)]))
+      builder.ret(builder.add(builder.extract_element(vector3, LLVM::Int32.from_i(0)),
+                              builder.extract_element(vector3, LLVM::Int32.from_i(1))))
     end
   end
 

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class VectorTestCase < Test::Unit::TestCase
+
+  def setup
+    LLVM.init_x86
+  end
+
+  def test_vector_elements
+    assert_equal 5, run_vector_elements().to_i
+  end
+
+  def run_vector_elements
+    run_function([], [], LLVM::Int) do |builder, function, *arguments|
+      entry = function.basic_blocks.append
+      builder.position_at_end(entry)
+      pointer = builder.alloca(LLVM::Vector(LLVM::Int, 2))
+      vector = builder.load(pointer)
+      vector = builder.insert_element(vector, LLVM::Int(2), LLVM::Int32.from_i(0))
+      vector = builder.insert_element(vector, LLVM::Int(3), LLVM::Int32.from_i(1))
+      builder.ret(builder.add(builder.extract_element(vector, LLVM::Int32.from_i(0)),
+                              builder.extract_element(vector, LLVM::Int32.from_i(1))))
+    end
+  end
+
+end

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -25,17 +25,17 @@ class VectorTestCase < Test::Unit::TestCase
   end
 
   def test_vector_elements
-    assert_equal 5, run_vector_elements().to_i
+    assert_equal 5, run_vector_elements(2, 3).to_i
   end
 
-  def run_vector_elements
-    run_function([], [], LLVM::Int) do |builder, function, *arguments|
+  def run_vector_elements(value1, value2)
+    run_function([LLVM::Int, LLVM::Int], [value1, value2], LLVM::Int) do |builder, function, *arguments|
       entry = function.basic_blocks.append
       builder.position_at_end(entry)
       pointer = builder.alloca(LLVM::Vector(LLVM::Int, 2))
       vector = builder.load(pointer)
-      vector = builder.insert_element(vector, LLVM::Int(2), LLVM::Int32.from_i(0))
-      vector = builder.insert_element(vector, LLVM::Int(3), LLVM::Int32.from_i(1))
+      vector = builder.insert_element(vector, arguments.first, LLVM::Int32.from_i(0))
+      vector = builder.insert_element(vector, arguments.last, LLVM::Int32.from_i(1))
       builder.ret(builder.add(builder.extract_element(vector, LLVM::Int32.from_i(0)),
                               builder.extract_element(vector, LLVM::Int32.from_i(1))))
     end


### PR DESCRIPTION
I added `ffi_lib` to load libs for LLVM 2.8. And furthermore, fixed some bugs and improved some stuff.
- Load libLLVM-2.8 if exists
- Added LLVM::FunctionPassManager
- Added LLVM::BasicBlock#parent, LLVM::BasicBlock.create
- and some fixes
