### PR TITLE
Added better pointer handling in GenericValue.

### DIFF
--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -26,6 +26,10 @@ module LLVM
         false
       end
     end
+    
+    def hash
+      @ptr.address.hash
+    end
 
     # Checks if the value is equal to other.
     def eql?(other)

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -425,6 +425,10 @@ module LLVM
     when Integer then Int.from_i(val)
     end
   end
+  
+  # Boolean values
+  ::LLVM::TRUE = ::LLVM::Int1.from_i(-1)
+  ::LLVM::FALSE = ::LLVM::Int1.from_i(0)
 
   class ConstantReal < Constant
     # Creates a ConstantReal from a float of Type.

--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -111,6 +111,11 @@ module LLVM
     def to_ptr
       @ptr
     end
+    
+    # Casts an FFI::Pointer pointing to a GenericValue to an instance.
+    def self.from_ptr(ptr)
+      new(ptr)
+    end
 
     # Creates a Generic Value from an integer. Type is the size of integer to
     # create (ex. Int32, Int8, etc.)
@@ -129,9 +134,9 @@ module LLVM
       from_i(b ? 1 : 0, LLVM::Int1, false)
     end
 
-    # Creates a GenericValue from an FFI::Pointer.
-    def self.from_ptr(ptr)
-      new(ptr)
+    # Creates a GenericValue from an FFI::Pointer pointing to some arbitrary value.
+    def self.from_value_ptr(ptr)
+      new(LLVM::C.LLVMCreateGenericValueOfPointer(ptr))
     end
 
     # Converts a GenericValue to a Ruby Integer.
@@ -159,6 +164,7 @@ module LLVM
     when ::Float then GenericValue.from_f(val)
     when ::TrueClass then GenericValue.from_b(true)
     when ::FalseClass then GenericValue.from_b(false)
+    when ::FFI::Pointer then GenericValue.from_value_ptr(val)
     end
   end
 end

--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -153,6 +153,10 @@ module LLVM
     def to_b
       to_i(false) != 0
     end
+    
+    def to_value_ptr
+      C.LLVMGenericValueToPointer(self)
+    end
   end
 
   # Creates a GenericValue from an object (GenericValue, Integer, Float, true,

--- a/lib/llvm/transforms/ipo.rb
+++ b/lib/llvm/transforms/ipo.rb
@@ -6,12 +6,18 @@ module LLVM
   # @private
   module C
     attach_function :LLVMAddGlobalDCEPass, [:pointer], :void
+    attach_function :LLVMAddFunctionInliningPass, [:pointer], :void
   end
 
   class PassManager
     # @LLVMpass gdce
     def gdce!
       C.LLVMAddGlobalDCEPass(self)
+    end
+    
+    # @LLVMpass inline
+    def inline!
+      C.LLVMAddFunctionInliningPass(self)
     end
   end
 end


### PR DESCRIPTION
Hi,

I just tried out ruby-llvm and got confused, because ExecutionEngine.run_function did not work as expected with pointers as arguments. It took some time to figure it out and I realized that it is a bit difficult to find appropriate method names there. So here is my solution.

Bye,
Richard
