### PR TITLE
LLVM 3.0 & named structs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-llvm (2.9.2)
+    ruby-llvm (3.0.0)
       ffi (>= 1.0.0)
 
 GEM

--- a/README.rdoc
+++ b/README.rdoc
@@ -20,7 +20,7 @@ ruby-llvm has been tested on Mac OS X 10.6 using the following Ruby interpreters
 If using MRI, ffi >= 1.0.7 is recommended (only ffi >= 1.0.0 is required).
 
 == Requirements
-* LLVM 2.9, including libLLVM-2.9 (compile LLVM with --enable-shared).
+* LLVM 3.0, including libLLVM-3.0 (compile LLVM with --enable-shared).
 * In order to ensure the usability of JIT features (i.e. create_jit_compiler), compile LLVM with --enable-jit as well.
 
 == About version numbers

--- a/ext/ruby-llvm-support/Rakefile
+++ b/ext/ruby-llvm-support/Rakefile
@@ -3,7 +3,7 @@ require 'ffi'
 
 CC = "g++"
 LLVM_CONFIG = `llvm-config --cxxflags --ldflags --libs all`.gsub("\n"," ")
-OUTPUT = FFI.map_library_name "RubyLLVMSupport-2.9.2"
+OUTPUT = FFI.map_library_name "RubyLLVMSupport-3.0.0"
 OUTPUT_DIR = "../../lib"
 SRC = "support.cpp"
 CLOBBER.include(OUTPUT)

--- a/ext/ruby-llvm-support/support.cpp
+++ b/ext/ruby-llvm-support/support.cpp
@@ -2,6 +2,7 @@
  * Extended bindings for LLVM.
  */
 
+#include <llvm/ADT/StringRef.h>
 #include <llvm/Support/DynamicLibrary.h>
 
 extern "C" {

--- a/lib/llvm.rb
+++ b/lib/llvm.rb
@@ -7,6 +7,6 @@ module LLVM
   # @private
   module C
     extend ::FFI::Library
-    ffi_lib ['LLVM-2.9']
+    ffi_lib ['LLVM-3.0']
   end
 end

--- a/lib/llvm/core/builder.rb
+++ b/lib/llvm/core/builder.rb
@@ -117,13 +117,6 @@ module LLVM
           fun, args, args.size, normal, exception, name))
     end
 
-    # Builds an unwind Instruction.
-    # @return [LLVM::Instruction]
-    # @LLVMinst unwind
-    def unwind
-      Instruction.from_ptr(C.LLVMBuildUnwind(self))
-    end
-
     # Generates an instruction with no defined semantics. Can be used to
     # provide hints to the optimizer.
     # @return [LLVM::Instruction]

--- a/lib/llvm/core/context.rb
+++ b/lib/llvm/core/context.rb
@@ -1,7 +1,7 @@
 module LLVM  
   class Context
-    def initialize
-      @ptr = C.LLVMContextCreate()
+    def initialize(ptr = nil)
+      @ptr = ptr || C.LLVMContextCreate()
     end
 
     # @private

--- a/lib/llvm/core/module.rb
+++ b/lib/llvm/core/module.rb
@@ -42,11 +42,6 @@ module LLVM
         @module = mod
       end
       
-      # Adds the given Type to the collection with the given name (symbol or string).
-      def add(name, type)
-        C.LLVMAddTypeName(@module, name.to_s, type)
-      end
-      
       # Returns the Type with the given name (symbol or string).
       def named(name)
         Type.from_ptr(C.LLVMGetTypeByName(@module, name.to_s))
@@ -149,7 +144,7 @@ module LLVM
       
       # Adds a Function with the given name (symbol or string) and args (Types).
       def add(name, *args)
-        if args.first.kind_of? Type
+        if args.first.kind_of? FunctionType
           type = args.first
         else
           type = Type.function(*args)

--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -45,11 +45,14 @@ module LLVM
     attach_function :LLVMInitializeX86TargetInfo, [], :void
 
     attach_function :LLVMInitializeX86Target, [], :void
+
+    attach_function :LLVMInitializeX86TargetMC, [], :void
   end
 
   def LLVM.init_x86
     LLVM::C.LLVMInitializeX86Target
     LLVM::C.LLVMInitializeX86TargetInfo
+    LLVM::C.LLVMInitializeX86TargetMC
   end
 
   class JITCompiler

--- a/lib/llvm/support.rb
+++ b/lib/llvm/support.rb
@@ -7,7 +7,7 @@ module LLVM
                       File.join(
                         File.dirname(__FILE__),
                         '../',
-                        FFI.map_library_name('RubyLLVMSupport-2.9.2')))
+                        FFI.map_library_name('RubyLLVMSupport-3.0.0')))
       ffi_lib [support_lib]
       attach_function :LLVMLoadLibraryPermanently, [:string], :int
     end

--- a/lib/llvm/version.rb
+++ b/lib/llvm/version.rb
@@ -1,4 +1,4 @@
 module LLVM
-  LLVM_VERSION = "2.9"
-  RUBY_LLVM_VERSION = "2.9.3"
+  LLVM_VERSION = "3.0"
+  RUBY_LLVM_VERSION = "3.0.0"
 end

--- a/test/equality_test.rb
+++ b/test/equality_test.rb
@@ -74,9 +74,9 @@ class EqualityTestCase < Test::Unit::TestCase
   def test_function
     mod = LLVM::Module.new('test')
 
-    fn1 = mod.functions.add('test1', LLVM.Void)
+    fn1 = mod.functions.add('test1', [], LLVM.Void)
     fn2 = LLVM::Function.from_ptr(fn1.to_ptr)
-    fn3 = mod.functions.add('test2', LLVM.Void)
+    fn3 = mod.functions.add('test2', [], LLVM.Void)
     fn4 = MyFunction.from_ptr(fn1.to_ptr)
 
     assert_equalities :equal     => [fn1, fn2, fn4],

--- a/test/struct_test.rb
+++ b/test/struct_test.rb
@@ -13,6 +13,12 @@ class StructTestCase < Test::Unit::TestCase
     struct = LLVM::Struct(LLVM::Int, LLVM::Float)
     assert_instance_of LLVM::Type, struct
   end
+  
+  def test_named_struct
+    struct = LLVM::Struct(LLVM::Int, LLVM::Float, "struct100")
+    assert_instance_of LLVM::Type, struct
+    assert_equal "struct100", struct.name
+  end
 
   def test_unpacked_constant_struct_from_size
     struct = LLVM::ConstantStruct.const(2, LLVM_UNPACKED) { |i| LLVM::Int(i) }


### PR DESCRIPTION
Hi Jeremy,

I just upgraded ruby-llvm to LLVM 3.0, because 2.9 had a memory leak and I wanted to use the named structures API. Would you like to pull it into your master? Or maybe you could start a branch for 3.0 support.

Bye,
Richard
