### PR TITLE
Finalizers and type system improvements

### DIFF
--- a/lib/llvm/analysis.rb
+++ b/lib/llvm/analysis.rb
@@ -31,12 +31,13 @@ module LLVM
     
     private
       def do_verification(action)
-        str = FFI::MemoryPointer.new(FFI.type_size(:pointer))
-        status = C.LLVMVerifyModule(self, action, str)
-        case status
-        when 1 then str.read_string
-        else nil
+        result = nil
+        FFI::MemoryPointer.new(FFI.type_size(:pointer)) do |str|
+          status = C.LLVMVerifyModule(self, action, str)
+          result = str.read_string if status == 1
+          C.LLVMDisposeMessage str.read_pointer
         end
+        result
       end
   end
   

--- a/lib/llvm/core/builder.rb
+++ b/lib/llvm/core/builder.rb
@@ -2,6 +2,11 @@ module LLVM
   class Builder
     def initialize
       @ptr = C.LLVMCreateBuilder()
+      ObjectSpace.define_finalizer self, Builder.dispose_builder_proc_for(@ptr)
+    end
+    
+    def self.dispose_builder_proc_for(ptr)
+      proc { C.LLVMDisposeBuilder(ptr) }
     end
 
     # @private
@@ -833,12 +838,6 @@ module LLVM
     #   pointers
     def ptr_diff(lhs, rhs, name = "")
       Instruction.from_ptr(C.LLVMBuildPtrDiff(lhs, rhs, name))
-    end
-
-    # Disposes the builder.
-    # @return nil
-    def dispose
-      C.LLVMDisposeBuilder(@ptr)
     end
   end
 end

--- a/lib/llvm/core/module.rb
+++ b/lib/llvm/core/module.rb
@@ -10,6 +10,11 @@ module LLVM
     
     def initialize(name)
       @ptr = C.LLVMModuleCreateWithName(name)
+      ObjectSpace.define_finalizer self, Module.dispose_module_proc_for(@ptr)
+    end
+    
+    def self.dispose_module_proc_for(ptr)
+      proc { C.LLVMDisposeModule(ptr) }
     end
     
     # @private
@@ -217,11 +222,6 @@ module LLVM
     # Print the module's IR to stdout.
     def dump
       C.LLVMDumpModule(self)
-    end
-    
-    # Dispose the module.
-    def dispose
-      C.LLVMDisposeModule(@ptr)
     end
   end
 end

--- a/lib/llvm/core/module.rb
+++ b/lib/llvm/core/module.rb
@@ -49,7 +49,7 @@ module LLVM
       
       # Returns the Type with the given name (symbol or string).
       def named(name)
-        Type.from_ptr(C.LLVMGetTypeByName(@module, name.to_s))
+        Type.from_ptr(C.LLVMGetTypeByName(@module, name.to_s), nil)
       end
       
       # Returns the Type with the a name equal to key (symbol or string).

--- a/lib/llvm/core/type.rb
+++ b/lib/llvm/core/type.rb
@@ -26,17 +26,7 @@ module LLVM
 
     # Returns a symbol representation of the types kind (ex. :pointer, :vector, :array.)
     def kind
-      C.LLVMGetTypeKind(self)
-    end
-    
-    # Returns a new instance of the appropriate type subclass if nesseccary.
-    def cast
-      case kind
-      when :integer  then IntType.from_ptr @ptr
-      when :function then FunctionType.from_ptr @ptr
-      when :struct   then StructType.from_ptr @ptr
-      else self
-      end
+      @kind
     end
 
     # Returns the size of the type.
@@ -52,7 +42,7 @@ module LLVM
     def element_type
       case self.kind
       when :pointer, :vector, :array
-        Type.from_ptr(C.LLVMGetElementType(self)).cast
+        Type.from_ptr(C.LLVMGetElementType(self), nil)
       end
     end
 
@@ -72,26 +62,33 @@ module LLVM
     end
     
     # @private
-    def self.from_ptr(ptr)
+    def self.from_ptr(ptr, kind)
       return if ptr.null?
-      ty = allocate
+      kind ||= C.LLVMGetTypeKind(ptr)
+      ty = case kind
+      when :integer  then IntType.allocate
+      when :function then FunctionType.allocate
+      when :struct   then StructType.allocate
+      else allocate
+      end
       ty.instance_variable_set(:@ptr, ptr)
+      ty.instance_variable_set(:@kind, kind)
       ty
     end
     
     # Creates an array type of Type with the given size.
     def self.array(ty, sz = 0)
-      from_ptr(C.LLVMArrayType(LLVM::Type(ty), sz))
+      from_ptr(C.LLVMArrayType(LLVM::Type(ty), sz), :array)
     end
     
     # Creates the pointer type of Type with the given address space.
     def self.pointer(ty, address_space = 0)
-      from_ptr(C.LLVMPointerType(LLVM::Type(ty), address_space))
+      from_ptr(C.LLVMPointerType(LLVM::Type(ty), address_space), :pointer)
     end
     
     # Creates a vector type of Type with the given element count.
     def self.vector(ty, element_count)
-      from_ptr(C.LLVMVectorType(LLVM::Type(ty), element_count))
+      from_ptr(C.LLVMVectorType(LLVM::Type(ty), element_count), :vector)
     end
     
     # Creates a function type. Takes an array of argument Types and the result Type. The only option is <tt>:varargs</tt>, 
@@ -100,7 +97,7 @@ module LLVM
       arg_types.map! { |ty| LLVM::Type(ty) }
       arg_types_ptr = FFI::MemoryPointer.new(FFI.type_size(:pointer) * arg_types.size)
       arg_types_ptr.write_array_of_pointer(arg_types)
-      FunctionType.from_ptr(C.LLVMFunctionType(LLVM::Type(result_type), arg_types_ptr, arg_types.size, options[:varargs] ? 1 : 0))
+      from_ptr(C.LLVMFunctionType(LLVM::Type(result_type), arg_types_ptr, arg_types.size, options[:varargs] ? 1 : 0), :function)
     end
     
     # Creates a struct type with the given array of element types.
@@ -109,17 +106,17 @@ module LLVM
       elt_types_ptr = FFI::MemoryPointer.new(FFI.type_size(:pointer) * elt_types.size)
       elt_types_ptr.write_array_of_pointer(elt_types)
       if name
-        struct = StructType.from_ptr(C.LLVMStructCreateNamed(Context.global, name))
+        struct = from_ptr(C.LLVMStructCreateNamed(Context.global, name), :struct)
         C.LLVMStructSetBody(struct, elt_types_ptr, elt_types.size, is_packed ? 1 : 0) unless elt_types.empty?
         struct
       else
-        StructType.from_ptr(C.LLVMStructType(elt_types_ptr, elt_types.size, is_packed ? 1 : 0))
+        from_ptr(C.LLVMStructType(elt_types_ptr, elt_types.size, is_packed ? 1 : 0), :struct)
       end
     end
 
     # Creates a void type.
     def self.void
-      from_ptr(C.LLVMVoidType)
+      from_ptr(C.LLVMVoidType, :void)
     end
     
     def self.rec
@@ -138,7 +135,7 @@ module LLVM
 
   class FunctionType < Type
     def return_type
-      LLVM::Type.from_ptr(C.LLVMGetReturnType(self))
+      Type.from_ptr(C.LLVMGetReturnType(self), nil)
     end
   end
   
@@ -154,7 +151,7 @@ module LLVM
       elt_types = nil
       FFI::MemoryPointer.new(FFI.type_size(:pointer) * count) do |types_ptr|
         C.LLVMGetStructElementTypes(self, types_ptr)
-        elt_types = types_ptr.read_array_of_pointer(count).map { |type_ptr| Type.from_ptr(type_ptr).cast }
+        elt_types = types_ptr.read_array_of_pointer(count).map { |type_ptr| Type.from_ptr(type_ptr, nil) }
       end
       elt_types
     end

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -43,7 +43,7 @@ module LLVM
 
     # Returns the value's type.
     def type
-      Type.from_ptr(C.LLVMTypeOf(self))
+      Type.from_ptr(C.LLVMTypeOf(self), nil)
     end
 
     # Returns the value's name.
@@ -394,7 +394,7 @@ module LLVM
       eval <<-KLASS
         class #{name} < ConstantInt
           def self.type
-            IntType.from_ptr(C.LLVMIntType(#{width}))
+            Type.from_ptr(C.LLVMIntType(#{width}), :integer)
           end
         end
       KLASS
@@ -481,7 +481,7 @@ module LLVM
   class Float < ConstantReal
     # Return a Type representation of the float.
     def self.type
-      Type.from_ptr(C.LLVMFloatType)
+      Type.from_ptr(C.LLVMFloatType, :float)
     end
   end
 
@@ -492,7 +492,7 @@ module LLVM
 
   class Double < ConstantReal
     def self.type
-      Type.from_ptr(C.LLVMDoubleType)
+      Type.from_ptr(C.LLVMDoubleType, :double)
     end
   end
 
@@ -597,7 +597,7 @@ module LLVM
     end
 
     def type
-      FunctionType.from_ptr(C.LLVMTypeOf(self))
+      Type.from_ptr(C.LLVMTypeOf(self), :function)
     end
 
     # @private

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -103,16 +103,9 @@ module LLVM
 
     # Build the basic block with the given builder. Creates a new one if nil. Yields the builder.
     def build(builder = nil)
-      if builder.nil?
-        builder = Builder.new
-        islocal = true
-      else
-        islocal = false
-      end
+      builder ||= Builder.new
       builder.position_at_end(self)
       yield builder
-    ensure
-      builder.dispose if islocal
     end
 
     # Returns the parent of this basic block (a Function).

--- a/test/equality_test.rb
+++ b/test/equality_test.rb
@@ -59,9 +59,9 @@ class EqualityTestCase < Test::Unit::TestCase
 
   def test_type
     type1 = LLVM::Float.type
-    type2 = LLVM::Type.from_ptr(type1.to_ptr)
+    type2 = LLVM::Type.from_ptr(type1.to_ptr, nil)
     type3 = LLVM::Double.type
-    type4 = MyType.from_ptr(type1.to_ptr)
+    type4 = MyType.from_ptr(type1.to_ptr, :mytype)
 
     assert_equalities :equal     => [type1, type2, type4],
                       :not_equal => [type1, type3],

--- a/test/struct_test.rb
+++ b/test/struct_test.rb
@@ -11,13 +11,22 @@ class StructTestCase < Test::Unit::TestCase
 
   def test_simple_struct
     struct = LLVM::Struct(LLVM::Int, LLVM::Float)
-    assert_instance_of LLVM::Type, struct
+    assert_instance_of LLVM::StructType, struct
+    assert_equal 2, struct.element_types.size
+    assert_equal LLVM::Int.type, struct.element_types[0]
+    assert_equal LLVM::Float.type, struct.element_types[1]
   end
   
   def test_named_struct
     struct = LLVM::Struct(LLVM::Int, LLVM::Float, "struct100")
-    assert_instance_of LLVM::Type, struct
+    assert_instance_of LLVM::StructType, struct
     assert_equal "struct100", struct.name
+  end
+  
+  def test_deferred_element_type_setting
+    struct = LLVM::Struct("struct200")
+    struct.element_types = [LLVM::Int, LLVM::Float]
+    assert_equal 2, struct.element_types.size
   end
 
   def test_unpacked_constant_struct_from_size


### PR DESCRIPTION
Hi again,

here comes the mentioned pull request with my changes to remove memory leaks. Finalizers are registered to automatically call the appropriate dispose method if an object is garbage collected. I also improved the code for LLVM types a bit.

I hope the changes are okay for you. All tests still pass.

Bye,
Richard
