### PR TITLE
Generate_ffi fails: ffi-gen renamed ruby_module to module_name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ffi_gen (>= 1.1.0)
   rake
   rcov
   ruby-llvm!

--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,7 @@ task :generate_ffi do
 
   mappings.each do |headers, ruby_file|
     FFIGen.generate(
-      :ruby_module => "LLVM::C",
+      :module_name => "LLVM::C",
       :ffi_lib     => "LLVM-3.0",
       :headers     => headers,
       :cflags      => `llvm-config --cflags`.split(" "),

--- a/ruby-llvm.gemspec
+++ b/ruby-llvm.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/jvoorhis/ruby-llvm"
 
   s.add_dependency("ffi", ">= 1.0.0")
-  s.add_development_dependency("ffi_gen")
+  s.add_development_dependency("ffi_gen", ">= 1.1.0")
   s.add_development_dependency("rake")
   s.add_development_dependency("rcov")
   s.add_development_dependency("yard")


### PR DESCRIPTION
In ffi-gen version 1.1.0 the FFIGen.generate() hash signature has changed :ruby_module to :module_name. The patch updates the Rake task and changes the development dependency to ffi-gen >= 1.1.0.
