### PR TITLE
Upgraded to support LLVM 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .yardoc
 coverage/*
 doc/*
+.bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,15 @@
 PATH
   remote: .
   specs:
-    ruby-llvm (3.0.0.beta)
+    ruby-llvm (3.1.0)
       ffi (>= 1.0.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    ffi (1.0.11)
+    ffi (1.1.5)
+    ffi_gen (1.1.0)
+      ffi (>= 1.0.0)
     rake (0.9.2)
     rcov (0.9.11)
     yard (0.7.4)
@@ -16,6 +18,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ffi_gen
   rake
   rcov
   ruby-llvm!

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ end
 
 task :generate_ffi do
   require 'ffi_gen'
-  
+
   mappings = {
     ["llvm-c/Core.h"] => "core_ffi.rb",
     ["llvm-c/Analysis.h"] => "analysis_ffi.rb",
@@ -45,8 +45,8 @@ task :generate_ffi do
 
   mappings.each do |headers, ruby_file|
     FFIGen.generate(
-      :ruby_module => "LLVM::C",
-      :ffi_lib     => "LLVM-3.0",
+      :module_name => "LLVM::C",
+      :ffi_lib     => "LLVM-3.1",
       :headers     => headers,
       :cflags      => `llvm-config --cflags`.split(" "),
       :prefixes    => ["LLVM"],

--- a/ext/ruby-llvm-support/Rakefile
+++ b/ext/ruby-llvm-support/Rakefile
@@ -4,7 +4,7 @@ require 'ffi'
 
 CC = "g++"
 LLVM_CONFIG = `llvm-config --cxxflags --ldflags --libs all`.gsub("\n"," ")
-OUTPUT = FFI.map_library_name "RubyLLVMSupport-3.0.0"
+OUTPUT = FFI.map_library_name "RubyLLVMSupport-3.1.0"
 OUTPUT_DIR = "../../lib"
 SRC = "support.cpp"
 CLOBBER.include(OUTPUT)

--- a/lib/llvm.rb
+++ b/lib/llvm.rb
@@ -7,6 +7,6 @@ module LLVM
   # @private
   module C
     extend ::FFI::Library
-    ffi_lib ['LLVM-3.0']
+    ffi_lib ['LLVM-3.1']
   end
 end

--- a/lib/llvm/analysis_ffi.rb
+++ b/lib/llvm/analysis_ffi.rb
@@ -4,9 +4,17 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib 'LLVM-3.0'
-
+  ffi_lib 'LLVM-3.1'
+  
+  def self.attach_function(name, *_)
+    begin; super; rescue FFI::NotFoundError => e
+      (class << self; self; end).class_eval { define_method(name) { |*_| raise e } }
+    end
+  end
+  
   # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:verifier_failure_action).</em>
   # 
   # === Options:
   # :abort_process ::
@@ -15,39 +23,38 @@ module LLVM::C
   #   verifier will print to stderr and abort()
   # :return_status ::
   #   verifier will print to stderr and return 1
-  #
-  # @return [Array<Symbol>]
-  def self.verifier_failure_action_enum
-    [:abort_process, :print_message, :return_status]
-  end
+  # 
+  # @method _enum_verifier_failure_action_
+  # @return [Symbol]
+  # @scope class
   enum :verifier_failure_action, [
-    :abort_process,
-    :print_message,
-    :return_status
+    :abort_process, 0,
+    :print_message, 1,
+    :return_status, 2
   ]
-
+  
   # Verifies that a module is valid, taking the specified action if not.
   #    Optionally returns a human-readable description of any invalid constructs.
   #    OutMessage must be disposed with LLVMDisposeMessage.
   # 
   # @method verify_module(m, action, out_message)
   # @param [FFI::Pointer(ModuleRef)] m 
-  # @param [Symbol from verifier_failure_action_enum] action 
-  # @param [FFI::Pointer(**Char_S)] out_message 
+  # @param [Symbol from _enum_verifier_failure_action_] action 
+  # @param [FFI::Pointer(**CharS)] out_message 
   # @return [Integer] 
   # @scope class
   attach_function :verify_module, :LLVMVerifyModule, [:pointer, :verifier_failure_action, :pointer], :int
-
+  
   # Verifies that a single function is valid, taking the specified action. Useful
   #    for debugging.
   # 
   # @method verify_function(fn, action)
   # @param [FFI::Pointer(ValueRef)] fn 
-  # @param [Symbol from verifier_failure_action_enum] action 
+  # @param [Symbol from _enum_verifier_failure_action_] action 
   # @return [Integer] 
   # @scope class
   attach_function :verify_function, :LLVMVerifyFunction, [:pointer, :verifier_failure_action], :int
-
+  
   # Open up a ghostview window that displays the CFG of the current function.
   #    Useful for debugging.
   # 
@@ -56,7 +63,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :view_function_cfg, :LLVMViewFunctionCFG, [:pointer], :void
-
+  
   # (Not documented)
   # 
   # @method view_function_cfg_only(fn)
@@ -64,5 +71,5 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :view_function_cfg_only, :LLVMViewFunctionCFGOnly, [:pointer], :void
-
+  
 end

--- a/lib/llvm/core/bitcode_ffi.rb
+++ b/lib/llvm/core/bitcode_ffi.rb
@@ -4,29 +4,35 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib 'LLVM-3.0'
-
+  ffi_lib 'LLVM-3.1'
+  
+  def self.attach_function(name, *_)
+    begin; super; rescue FFI::NotFoundError => e
+      (class << self; self; end).class_eval { define_method(name) { |*_| raise e } }
+    end
+  end
+  
   # (Not documented)
   # 
   # @method parse_bitcode(mem_buf, out_module, out_message)
   # @param [FFI::Pointer(MemoryBufferRef)] mem_buf 
   # @param [FFI::Pointer(*ModuleRef)] out_module 
-  # @param [FFI::Pointer(**Char_S)] out_message 
+  # @param [FFI::Pointer(**CharS)] out_message 
   # @return [Integer] 
   # @scope class
   attach_function :parse_bitcode, :LLVMParseBitcode, [:pointer, :pointer, :pointer], :int
-
+  
   # (Not documented)
   # 
   # @method parse_bitcode_in_context(context_ref, mem_buf, out_module, out_message)
   # @param [FFI::Pointer(ContextRef)] context_ref 
   # @param [FFI::Pointer(MemoryBufferRef)] mem_buf 
   # @param [FFI::Pointer(*ModuleRef)] out_module 
-  # @param [FFI::Pointer(**Char_S)] out_message 
+  # @param [FFI::Pointer(**CharS)] out_message 
   # @return [Integer] 
   # @scope class
   attach_function :parse_bitcode_in_context, :LLVMParseBitcodeInContext, [:pointer, :pointer, :pointer, :pointer], :int
-
+  
   # Reads a module from the specified path, returning via the OutMP parameter
   #     a module provider which performs lazy deserialization. Returns 0 on success.
   #     Optionally returns a human-readable error message via OutMessage.
@@ -35,42 +41,42 @@ module LLVM::C
   # @param [FFI::Pointer(ContextRef)] context_ref 
   # @param [FFI::Pointer(MemoryBufferRef)] mem_buf 
   # @param [FFI::Pointer(*ModuleRef)] out_m 
-  # @param [FFI::Pointer(**Char_S)] out_message 
+  # @param [FFI::Pointer(**CharS)] out_message 
   # @return [Integer] 
   # @scope class
   attach_function :get_bitcode_module_in_context, :LLVMGetBitcodeModuleInContext, [:pointer, :pointer, :pointer, :pointer], :int
-
+  
   # (Not documented)
   # 
   # @method get_bitcode_module(mem_buf, out_m, out_message)
   # @param [FFI::Pointer(MemoryBufferRef)] mem_buf 
   # @param [FFI::Pointer(*ModuleRef)] out_m 
-  # @param [FFI::Pointer(**Char_S)] out_message 
+  # @param [FFI::Pointer(**CharS)] out_message 
   # @return [Integer] 
   # @scope class
   attach_function :get_bitcode_module, :LLVMGetBitcodeModule, [:pointer, :pointer, :pointer], :int
-
+  
   # Deprecated: Use LLVMGetBitcodeModuleInContext instead.
   # 
   # @method get_bitcode_module_provider_in_context(context_ref, mem_buf, out_mp, out_message)
   # @param [FFI::Pointer(ContextRef)] context_ref 
   # @param [FFI::Pointer(MemoryBufferRef)] mem_buf 
   # @param [FFI::Pointer(*ModuleProviderRef)] out_mp 
-  # @param [FFI::Pointer(**Char_S)] out_message 
+  # @param [FFI::Pointer(**CharS)] out_message 
   # @return [Integer] 
   # @scope class
   attach_function :get_bitcode_module_provider_in_context, :LLVMGetBitcodeModuleProviderInContext, [:pointer, :pointer, :pointer, :pointer], :int
-
+  
   # Deprecated: Use LLVMGetBitcodeModule instead.
   # 
   # @method get_bitcode_module_provider(mem_buf, out_mp, out_message)
   # @param [FFI::Pointer(MemoryBufferRef)] mem_buf 
   # @param [FFI::Pointer(*ModuleProviderRef)] out_mp 
-  # @param [FFI::Pointer(**Char_S)] out_message 
+  # @param [FFI::Pointer(**CharS)] out_message 
   # @return [Integer] 
   # @scope class
   attach_function :get_bitcode_module_provider, :LLVMGetBitcodeModuleProvider, [:pointer, :pointer, :pointer], :int
-
+  
   # (Not documented)
   # 
   # @method write_bitcode_to_file(m, path)
@@ -79,7 +85,7 @@ module LLVM::C
   # @return [Integer] 
   # @scope class
   attach_function :write_bitcode_to_file, :LLVMWriteBitcodeToFile, [:pointer, :string], :int
-
+  
   # Writes a module to an open file descriptor. Returns 0 on success.
   # 
   # @method write_bitcode_to_fd(m, fd, should_close, unbuffered)
@@ -90,7 +96,7 @@ module LLVM::C
   # @return [Integer] 
   # @scope class
   attach_function :write_bitcode_to_fd, :LLVMWriteBitcodeToFD, [:pointer, :int, :int, :int], :int
-
+  
   # Deprecated for LLVMWriteBitcodeToFD. Writes a module to an open file
   #     descriptor. Returns 0 on success. Closes the Handle.
   # 
@@ -100,5 +106,5 @@ module LLVM::C
   # @return [Integer] 
   # @scope class
   attach_function :write_bitcode_to_file_handle, :LLVMWriteBitcodeToFileHandle, [:pointer, :int], :int
-
+  
 end

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -22,7 +22,7 @@ module LLVM
         false
       end
     end
-    
+
     def hash
       @ptr.address.hash
     end
@@ -280,6 +280,10 @@ module LLVM
       vals = LLVM::Support.allocate_pointers(size_or_values, &block)
       from_ptr C.const_array(type, vals, vals.size / vals.type_size)
     end
+
+    def size
+      C.get_array_length(type)
+    end
   end
 
   class ConstantExpr < Constant
@@ -421,7 +425,7 @@ module LLVM
     when Integer then Int.from_i(val)
     end
   end
-  
+
   # Boolean values
   ::LLVM::TRUE = ::LLVM::Int1.from_i(-1)
   ::LLVM::FALSE = ::LLVM::Int1.from_i(0)
@@ -523,6 +527,10 @@ module LLVM
     def self.const(size_or_values, &block)
       vals = LLVM::Support.allocate_pointers(size_or_values, &block)
       from_ptr(C.const_vector(vals, vals.size / vals.type_size))
+    end
+
+    def size
+      C.get_vector_size(type)
     end
   end
 

--- a/lib/llvm/core_ffi.rb
+++ b/lib/llvm/core_ffi.rb
@@ -4,103 +4,176 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib 'LLVM-3.0'
-
-  # The top-level container for all LLVM global data.  See the LLVMContext class.
-  # 
-  # = Fields:
-  #
+  ffi_lib 'LLVM-3.1'
+  
+  def self.attach_function(name, *_)
+    begin; super; rescue FFI::NotFoundError => e
+      (class << self; self; end).class_eval { define_method(name) { |*_| raise e } }
+    end
+  end
+  
+  # The top-level container for all LLVM global data. See the LLVMContext class.
   class OpaqueContext < FFI::Struct
+    layout :dummy, :char
   end
-
+  
   # The top-level container for all other LLVM Intermediate Representation (IR)
-  # objects. See the llvm::Module class.
+  # objects.
   # 
-  # = Fields:
-  #
+  # @see llvm::Module
   class OpaqueModule < FFI::Struct
+    layout :dummy, :char
   end
-
-  # Each value in the LLVM IR has a type, an LLVMTypeRef. See the llvm::Type
-  # class.
+  
+  # Each value in the LLVM IR has a type, an LLVMTypeRef.
   # 
-  # = Fields:
-  #
+  # @see llvm::Type
   class OpaqueType < FFI::Struct
+    layout :dummy, :char
   end
-
-  # (Not documented)
+  
+  # Represents an individual value in LLVM IR.
   # 
-  # = Fields:
-  #
+  # This models llvm::Value.
   class OpaqueValue < FFI::Struct
+    layout :dummy, :char
   end
-
-  # (Not documented)
+  
+  # Represents a basic block of instruction in LLVM IR.
   # 
-  # = Fields:
-  #
+  # This models llvm::BasicBlock.
   class OpaqueBasicBlock < FFI::Struct
+    layout :dummy, :char
   end
-
-  # (Not documented)
+  
+  # Represents an LLVM basic block builder.
   # 
-  # = Fields:
-  #
+  # This models llvm::IRBuilder.
   class OpaqueBuilder < FFI::Struct
+    layout :dummy, :char
   end
-
-  # Interface used to provide a module to JIT or interpreter.  This is now just a
-  # synonym for llvm::Module, but we have to keep using the different type to
-  # keep binary compatibility.
-  # 
-  # = Fields:
-  #
+  
+  # Interface used to provide a module to JIT or interpreter.
+  # This is now just a synonym for llvm::Module, but we have to keep using the
+  # different type to keep binary compatibility.
   class OpaqueModuleProvider < FFI::Struct
+    layout :dummy, :char
   end
-
+  
   # Used to provide a module to JIT or interpreter.
-  # See the llvm::MemoryBuffer class.
   # 
-  # = Fields:
-  #
+  # @see llvm::MemoryBuffer
   class OpaqueMemoryBuffer < FFI::Struct
+    layout :dummy, :char
   end
-
-  # See the llvm::PassManagerBase class.
-  # 
-  # = Fields:
-  #
+  
+  # @see llvm::PassManagerBase
   class OpaquePassManager < FFI::Struct
+    layout :dummy, :char
   end
-
-  # See the llvm::PassRegistry class.
-  # 
-  # = Fields:
-  #
+  
+  # @see llvm::PassRegistry
   class OpaquePassRegistry < FFI::Struct
+    layout :dummy, :char
   end
-
-  # Used to get the users and usees of a Value. See the llvm::Use class.
+  
+  # Used to get the users and usees of a Value.
   # 
-  # = Fields:
-  #
+  # @see llvm::Use
   class OpaqueUse < FFI::Struct
+    layout :dummy, :char
   end
-
+  
   # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:attribute).</em>
   # 
   # === Options:
-  #
-  # @return [Array<Symbol>]
-  def self.attribute_enum
-    []
-  end
+  # :z_ext_attribute ::
+  #   
+  # :s_ext_attribute ::
+  #   
+  # :no_return_attribute ::
+  #   
+  # :in_reg_attribute ::
+  #   
+  # :struct_ret_attribute ::
+  #   
+  # :no_unwind_attribute ::
+  #   
+  # :no_alias_attribute ::
+  #   
+  # :by_val_attribute ::
+  #   
+  # :nest_attribute ::
+  #   
+  # :read_none_attribute ::
+  #   
+  # :read_only_attribute ::
+  #   
+  # :no_inline_attribute ::
+  #   
+  # :always_inline_attribute ::
+  #   
+  # :optimize_for_size_attribute ::
+  #   
+  # :stack_protect_attribute ::
+  #   
+  # :stack_protect_req_attribute ::
+  #   
+  # :alignment ::
+  #   
+  # :no_capture_attribute ::
+  #   
+  # :no_red_zone_attribute ::
+  #   
+  # :no_implicit_float_attribute ::
+  #   
+  # :naked_attribute ::
+  #   
+  # :inline_hint_attribute ::
+  #   
+  # :stack_alignment ::
+  #   
+  # :returns_twice ::
+  #   
+  # :uw_table ::
+  #   
+  # 
+  # @method _enum_attribute_
+  # @return [Symbol]
+  # @scope class
   enum :attribute, [
-
+    :z_ext_attribute, 1,
+    :s_ext_attribute, 2,
+    :no_return_attribute, 4,
+    :in_reg_attribute, 8,
+    :struct_ret_attribute, 16,
+    :no_unwind_attribute, 32,
+    :no_alias_attribute, 64,
+    :by_val_attribute, 128,
+    :nest_attribute, 256,
+    :read_none_attribute, 512,
+    :read_only_attribute, 1024,
+    :no_inline_attribute, 2048,
+    :always_inline_attribute, 4096,
+    :optimize_for_size_attribute, 8192,
+    :stack_protect_attribute, 16384,
+    :stack_protect_req_attribute, 32768,
+    :alignment, 2031616,
+    :no_capture_attribute, 2097152,
+    :no_red_zone_attribute, 4194304,
+    :no_implicit_float_attribute, 8388608,
+    :naked_attribute, 16777216,
+    :inline_hint_attribute, 33554432,
+    :stack_alignment, 469762048,
+    :returns_twice, 536870912,
+    :uw_table, 1073741824
   ]
-
+  
   # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:opcode).</em>
   # 
   # === Options:
   # :ret ::
@@ -145,9 +218,9 @@ module LLVM::C
   #   
   # :a_shr ::
   #   
-  # :and ::
+  # :and_ ::
   #   
-  # :or ::
+  # :or_ ::
   #   
   # :xor ::
   #   
@@ -219,13 +292,10 @@ module LLVM::C
   #   Exception Handling Operators
   # :landing_pad ::
   #   
-  # :unwind ::
-  #   
-  #
-  # @return [Array<Symbol>]
-  def self.opcode_enum
-    [:ret, :br, :switch, :indirect_br, :invoke, :unreachable, :add, :f_add, :sub, :f_sub, :mul, :f_mul, :u_div, :s_div, :f_div, :u_rem, :s_rem, :f_rem, :shl, :l_shr, :a_shr, :and, :or, :xor, :alloca, :load, :store, :get_element_ptr, :trunc, :z_ext, :s_ext, :fp_to_ui, :fp_to_si, :ui_to_fp, :si_to_fp, :fp_trunc, :fp_ext, :ptr_to_int, :int_to_ptr, :bit_cast, :i_cmp, :f_cmp, :phi, :call, :select, :user_op1, :user_op2, :va_arg, :extract_element, :insert_element, :shuffle_vector, :extract_value, :insert_value, :fence, :atomic_cmp_xchg, :atomic_rmw, :resume, :landing_pad, :unwind]
-  end
+  # 
+  # @method _enum_opcode_
+  # @return [Symbol]
+  # @scope class
   enum :opcode, [
     :ret, 1,
     :br, 2,
@@ -248,8 +318,8 @@ module LLVM::C
     :shl, 20,
     :l_shr, 21,
     :a_shr, 22,
-    :and, 23,
-    :or, 24,
+    :and_, 23,
+    :or_, 24,
     :xor, 25,
     :alloca, 26,
     :load, 27,
@@ -284,17 +354,20 @@ module LLVM::C
     :atomic_cmp_xchg, 56,
     :atomic_rmw, 57,
     :resume, 58,
-    :landing_pad, 59,
-    :unwind, 60
+    :landing_pad, 59
   ]
-
+  
   # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:type_kind).</em>
   # 
   # === Options:
   # :void ::
   #   
-  # :float ::
+  # :half ::
   #   < type with no size
+  # :float ::
+  #   < 16 bit floating point type
   # :double ::
   #   < 32 bit floating point type
   # :x86_fp80 ::
@@ -321,30 +394,32 @@ module LLVM::C
   #   < SIMD 'packed' format, or other vector type
   # :x86_mmx ::
   #   < Metadata
-  #
-  # @return [Array<Symbol>]
-  def self.type_kind_enum
-    [:void, :float, :double, :x86_fp80, :fp128, :ppc_fp128, :label, :integer, :function, :struct, :array, :pointer, :vector, :metadata, :x86_mmx]
-  end
+  # 
+  # @method _enum_type_kind_
+  # @return [Symbol]
+  # @scope class
   enum :type_kind, [
-    :void,
-    :float,
-    :double,
-    :x86_fp80,
-    :fp128,
-    :ppc_fp128,
-    :label,
-    :integer,
-    :function,
-    :struct,
-    :array,
-    :pointer,
-    :vector,
-    :metadata,
-    :x86_mmx
+    :void, 0,
+    :half, 1,
+    :float, 2,
+    :double, 3,
+    :x86_fp80, 4,
+    :fp128, 5,
+    :ppc_fp128, 6,
+    :label, 7,
+    :integer, 8,
+    :function, 9,
+    :struct, 10,
+    :array, 11,
+    :pointer, 12,
+    :vector, 13,
+    :metadata, 14,
+    :x86_mmx, 15
   ]
-
+  
   # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:linkage).</em>
   # 
   # === Options:
   # :external ::
@@ -384,32 +459,33 @@ module LLVM::C
   #   < Like Private, but linker removes.
   # :linker_private_weak_def_auto ::
   #   < Like LinkerPrivate, but is weak.
-  #
-  # @return [Array<Symbol>]
-  def self.linkage_enum
-    [:external, :available_externally, :link_once_any, :link_once_odr, :weak_any, :weak_odr, :appending, :internal, :private, :dll_import, :dll_export, :external_weak, :ghost, :common, :linker_private, :linker_private_weak, :linker_private_weak_def_auto]
-  end
+  # 
+  # @method _enum_linkage_
+  # @return [Symbol]
+  # @scope class
   enum :linkage, [
-    :external,
-    :available_externally,
-    :link_once_any,
-    :link_once_odr,
-    :weak_any,
-    :weak_odr,
-    :appending,
-    :internal,
-    :private,
-    :dll_import,
-    :dll_export,
-    :external_weak,
-    :ghost,
-    :common,
-    :linker_private,
-    :linker_private_weak,
-    :linker_private_weak_def_auto
+    :external, 0,
+    :available_externally, 1,
+    :link_once_any, 2,
+    :link_once_odr, 3,
+    :weak_any, 4,
+    :weak_odr, 5,
+    :appending, 6,
+    :internal, 7,
+    :private, 8,
+    :dll_import, 9,
+    :dll_export, 10,
+    :external_weak, 11,
+    :ghost, 12,
+    :common, 13,
+    :linker_private, 14,
+    :linker_private_weak, 15,
+    :linker_private_weak_def_auto, 16
   ]
-
+  
   # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:visibility).</em>
   # 
   # === Options:
   # :default ::
@@ -418,18 +494,19 @@ module LLVM::C
   #   < The GV is visible
   # :protected ::
   #   < The GV is hidden
-  #
-  # @return [Array<Symbol>]
-  def self.visibility_enum
-    [:default, :hidden, :protected]
-  end
+  # 
+  # @method _enum_visibility_
+  # @return [Symbol]
+  # @scope class
   enum :visibility, [
-    :default,
-    :hidden,
-    :protected
+    :default, 0,
+    :hidden, 1,
+    :protected, 2
   ]
-
+  
   # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:call_conv).</em>
   # 
   # === Options:
   # :c ::
@@ -442,11 +519,10 @@ module LLVM::C
   #   
   # :x86_fastcall ::
   #   
-  #
-  # @return [Array<Symbol>]
-  def self.call_conv_enum
-    [:c, :fast, :cold, :x86_stdcall, :x86_fastcall]
-  end
+  # 
+  # @method _enum_call_conv_
+  # @return [Symbol]
+  # @scope class
   enum :call_conv, [
     :c, 0,
     :fast, 8,
@@ -454,8 +530,10 @@ module LLVM::C
     :x86_stdcall, 64,
     :x86_fastcall, 65
   ]
-
+  
   # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:int_predicate).</em>
   # 
   # === Options:
   # :eq ::
@@ -478,25 +556,26 @@ module LLVM::C
   #   < signed greater or equal
   # :sle ::
   #   < signed less than
-  #
-  # @return [Array<Symbol>]
-  def self.int_predicate_enum
-    [:eq, :ne, :ugt, :uge, :ult, :ule, :sgt, :sge, :slt, :sle]
-  end
+  # 
+  # @method _enum_int_predicate_
+  # @return [Symbol]
+  # @scope class
   enum :int_predicate, [
     :eq, 32,
-    :ne,
-    :ugt,
-    :uge,
-    :ult,
-    :ule,
-    :sgt,
-    :sge,
-    :slt,
-    :sle
+    :ne, 33,
+    :ugt, 34,
+    :uge, 35,
+    :ult, 36,
+    :ule, 37,
+    :sgt, 38,
+    :sge, 39,
+    :slt, 40,
+    :sle, 41
   ]
-
+  
   # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:real_predicate).</em>
   # 
   # === Options:
   # :predicate_false ::
@@ -531,55 +610,55 @@ module LLVM::C
   #   < True if unordered, less than, or equal
   # :predicate_true ::
   #   < True if unordered or not equal
-  #
-  # @return [Array<Symbol>]
-  def self.real_predicate_enum
-    [:predicate_false, :oeq, :ogt, :oge, :olt, :ole, :one, :ord, :uno, :ueq, :ugt, :uge, :ult, :ule, :une, :predicate_true]
-  end
+  # 
+  # @method _enum_real_predicate_
+  # @return [Symbol]
+  # @scope class
   enum :real_predicate, [
-    :predicate_false,
-    :oeq,
-    :ogt,
-    :oge,
-    :olt,
-    :ole,
-    :one,
-    :ord,
-    :uno,
-    :ueq,
-    :ugt,
-    :uge,
-    :ult,
-    :ule,
-    :une,
-    :predicate_true
+    :predicate_false, 0,
+    :oeq, 1,
+    :ogt, 2,
+    :oge, 3,
+    :olt, 4,
+    :ole, 5,
+    :one, 6,
+    :ord, 7,
+    :uno, 8,
+    :ueq, 9,
+    :ugt, 10,
+    :uge, 11,
+    :ult, 12,
+    :ule, 13,
+    :une, 14,
+    :predicate_true, 15
   ]
-
+  
   # (Not documented)
+  # 
+  # <em>This entry is only for documentation and no real method. The FFI::Enum can be accessed via #enum_type(:landing_pad_clause_ty).</em>
   # 
   # === Options:
   # :catch ::
   #   
   # :filter ::
   #   < A catch clause  
-  #
-  # @return [Array<Symbol>]
-  def self.landing_pad_clause_ty_enum
-    [:catch, :filter]
-  end
+  # 
+  # @method _enum_landing_pad_clause_ty_
+  # @return [Symbol]
+  # @scope class
   enum :landing_pad_clause_ty, [
-    :catch,
-    :filter
+    :catch, 0,
+    :filter, 1
   ]
-
-  # (Not documented)
+  
+  # @}
   # 
   # @method initialize_core(r)
-  # @param [FFI::Pointer(PassRegistryRef)] r 
+  # @param [OpaquePassRegistry] r 
   # @return [nil] 
   # @scope class
-  attach_function :initialize_core, :LLVMInitializeCore, [:pointer], :void
-
+  attach_function :initialize_core, :LLVMInitializeCore, [OpaquePassRegistry], :void
+  
   # ===-- Error handling ----------------------------------------------------===
   # 
   # @method dispose_message(message)
@@ -587,39 +666,45 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :dispose_message, :LLVMDisposeMessage, [:string], :void
-
-  # Create and destroy contexts.
+  
+  # Create a new context.
+  # 
+  # Every call to this function should be paired with a call to
+  # LLVMContextDispose() or the context will leak memory.
   # 
   # @method context_create()
-  # @return [FFI::Pointer(ContextRef)] 
+  # @return [OpaqueContext] 
   # @scope class
-  attach_function :context_create, :LLVMContextCreate, [], :pointer
-
-  # (Not documented)
+  attach_function :context_create, :LLVMContextCreate, [], OpaqueContext
+  
+  # Obtain the global context instance.
   # 
   # @method get_global_context()
-  # @return [FFI::Pointer(ContextRef)] 
+  # @return [OpaqueContext] 
   # @scope class
-  attach_function :get_global_context, :LLVMGetGlobalContext, [], :pointer
-
-  # (Not documented)
+  attach_function :get_global_context, :LLVMGetGlobalContext, [], OpaqueContext
+  
+  # Destroy a context instance.
+  # 
+  # This should be called for every call to LLVMContextCreate() or memory
+  # will be leaked.
   # 
   # @method context_dispose(c)
-  # @param [FFI::Pointer(ContextRef)] c 
+  # @param [OpaqueContext] c 
   # @return [nil] 
   # @scope class
-  attach_function :context_dispose, :LLVMContextDispose, [:pointer], :void
-
+  attach_function :context_dispose, :LLVMContextDispose, [OpaqueContext], :void
+  
   # (Not documented)
   # 
   # @method get_md_kind_id_in_context(c, name, s_len)
-  # @param [FFI::Pointer(ContextRef)] c 
+  # @param [OpaqueContext] c 
   # @param [String] name 
   # @param [Integer] s_len 
   # @return [Integer] 
   # @scope class
-  attach_function :get_md_kind_id_in_context, :LLVMGetMDKindIDInContext, [:pointer, :string, :uint], :uint
-
+  attach_function :get_md_kind_id_in_context, :LLVMGetMDKindIDInContext, [OpaqueContext, :string, :uint], :uint
+  
   # (Not documented)
   # 
   # @method get_md_kind_id(name, s_len)
@@ -628,4085 +713,4544 @@ module LLVM::C
   # @return [Integer] 
   # @scope class
   attach_function :get_md_kind_id, :LLVMGetMDKindID, [:string, :uint], :uint
-
-  # See llvm::Module::Module.
+  
+  # Create a new, empty module in the global context.
+  # 
+  # This is equivalent to calling LLVMModuleCreateWithNameInContext with
+  # LLVMGetGlobalContext() as the context parameter.
+  # 
+  # Every invocation should be paired with LLVMDisposeModule() or memory
+  # will be leaked.
   # 
   # @method module_create_with_name(module_id)
   # @param [String] module_id 
-  # @return [FFI::Pointer(ModuleRef)] 
+  # @return [OpaqueModule] 
   # @scope class
-  attach_function :module_create_with_name, :LLVMModuleCreateWithName, [:string], :pointer
-
-  # (Not documented)
+  attach_function :module_create_with_name, :LLVMModuleCreateWithName, [:string], OpaqueModule
+  
+  # Create a new, empty module in a specific context.
+  # 
+  # Every invocation should be paired with LLVMDisposeModule() or memory
+  # will be leaked.
   # 
   # @method module_create_with_name_in_context(module_id, c)
   # @param [String] module_id 
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(ModuleRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueModule] 
   # @scope class
-  attach_function :module_create_with_name_in_context, :LLVMModuleCreateWithNameInContext, [:string, :pointer], :pointer
-
-  # See llvm::Module::~Module.
+  attach_function :module_create_with_name_in_context, :LLVMModuleCreateWithNameInContext, [:string, OpaqueContext], OpaqueModule
+  
+  # Destroy a module instance.
+  # 
+  # This must be called for every created module or memory will be
+  # leaked.
   # 
   # @method dispose_module(m)
-  # @param [FFI::Pointer(ModuleRef)] m 
+  # @param [OpaqueModule] m 
   # @return [nil] 
   # @scope class
-  attach_function :dispose_module, :LLVMDisposeModule, [:pointer], :void
-
-  # Data layout. See Module::getDataLayout.
+  attach_function :dispose_module, :LLVMDisposeModule, [OpaqueModule], :void
+  
+  # Obtain the data layout for a module.
+  # 
+  # @see Module::getDataLayout()
   # 
   # @method get_data_layout(m)
-  # @param [FFI::Pointer(ModuleRef)] m 
+  # @param [OpaqueModule] m 
   # @return [String] 
   # @scope class
-  attach_function :get_data_layout, :LLVMGetDataLayout, [:pointer], :string
-
-  # (Not documented)
+  attach_function :get_data_layout, :LLVMGetDataLayout, [OpaqueModule], :string
+  
+  # Set the data layout for a module.
+  # 
+  # @see Module::setDataLayout()
   # 
   # @method set_data_layout(m, triple)
-  # @param [FFI::Pointer(ModuleRef)] m 
+  # @param [OpaqueModule] m 
   # @param [String] triple 
   # @return [nil] 
   # @scope class
-  attach_function :set_data_layout, :LLVMSetDataLayout, [:pointer, :string], :void
-
-  # Target triple. See Module::getTargetTriple.
+  attach_function :set_data_layout, :LLVMSetDataLayout, [OpaqueModule, :string], :void
+  
+  # Obtain the target triple for a module.
+  # 
+  # @see Module::getTargetTriple()
   # 
   # @method get_target(m)
-  # @param [FFI::Pointer(ModuleRef)] m 
+  # @param [OpaqueModule] m 
   # @return [String] 
   # @scope class
-  attach_function :get_target, :LLVMGetTarget, [:pointer], :string
-
-  # (Not documented)
+  attach_function :get_target, :LLVMGetTarget, [OpaqueModule], :string
+  
+  # Set the target triple for a module.
+  # 
+  # @see Module::setTargetTriple()
   # 
   # @method set_target(m, triple)
-  # @param [FFI::Pointer(ModuleRef)] m 
+  # @param [OpaqueModule] m 
   # @param [String] triple 
   # @return [nil] 
   # @scope class
-  attach_function :set_target, :LLVMSetTarget, [:pointer, :string], :void
-
-  # See Module::dump.
+  attach_function :set_target, :LLVMSetTarget, [OpaqueModule, :string], :void
+  
+  # Dump a representation of a module to stderr.
+  # 
+  # @see Module::dump()
   # 
   # @method dump_module(m)
-  # @param [FFI::Pointer(ModuleRef)] m 
+  # @param [OpaqueModule] m 
   # @return [nil] 
   # @scope class
-  attach_function :dump_module, :LLVMDumpModule, [:pointer], :void
-
-  # See Module::setModuleInlineAsm.
+  attach_function :dump_module, :LLVMDumpModule, [OpaqueModule], :void
+  
+  # Set inline assembly for a module.
+  # 
+  # @see Module::setModuleInlineAsm()
   # 
   # @method set_module_inline_asm(m, asm)
-  # @param [FFI::Pointer(ModuleRef)] m 
+  # @param [OpaqueModule] m 
   # @param [String] asm 
   # @return [nil] 
   # @scope class
-  attach_function :set_module_inline_asm, :LLVMSetModuleInlineAsm, [:pointer, :string], :void
-
-  # See Module::getContext.
+  attach_function :set_module_inline_asm, :LLVMSetModuleInlineAsm, [OpaqueModule, :string], :void
+  
+  # Obtain the context to which this module is associated.
+  # 
+  # @see Module::getContext()
   # 
   # @method get_module_context(m)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @return [FFI::Pointer(ContextRef)] 
+  # @param [OpaqueModule] m 
+  # @return [OpaqueContext] 
   # @scope class
-  attach_function :get_module_context, :LLVMGetModuleContext, [:pointer], :pointer
-
-  # See llvm::LLVMTypeKind::getTypeID.
+  attach_function :get_module_context, :LLVMGetModuleContext, [OpaqueModule], OpaqueContext
+  
+  # Obtain a Type from a module by its registered name.
   # 
-  # @method get_type_kind(ty)
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @return [Symbol from type_kind_enum] 
+  # @method get_type_by_name(m, name)
+  # @param [OpaqueModule] m 
+  # @param [String] name 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :get_type_kind, :LLVMGetTypeKind, [:pointer], :type_kind
-
-  # (Not documented)
+  attach_function :get_type_by_name, :LLVMGetTypeByName, [OpaqueModule, :string], OpaqueType
+  
+  # Obtain the number of operands for named metadata in a module.
   # 
-  # @method type_is_sized(ty)
-  # @param [FFI::Pointer(TypeRef)] ty 
+  # @see llvm::Module::getNamedMetadata()
+  # 
+  # @method get_named_metadata_num_operands(m, name)
+  # @param [OpaqueModule] m 
+  # @param [String] name 
   # @return [Integer] 
   # @scope class
-  attach_function :type_is_sized, :LLVMTypeIsSized, [:pointer], :int
-
-  # See llvm::LLVMType::getContext.
+  attach_function :get_named_metadata_num_operands, :LLVMGetNamedMetadataNumOperands, [OpaqueModule, :string], :uint
+  
+  # Obtain the named metadata operands for a module.
+  # 
+  # The passed LLVMValueRef pointer should refer to an array of
+  # LLVMValueRef at least LLVMGetNamedMetadataNumOperands long. This
+  # array will be populated with the LLVMValueRef instances. Each
+  # instance corresponds to a llvm::MDNode.
+  # 
+  # @see llvm::Module::getNamedMetadata()
+  # @see llvm::MDNode::getOperand()
+  # 
+  # @method get_named_metadata_operands(m, name, dest)
+  # @param [OpaqueModule] m 
+  # @param [String] name 
+  # @param [FFI::Pointer(*ValueRef)] dest 
+  # @return [nil] 
+  # @scope class
+  attach_function :get_named_metadata_operands, :LLVMGetNamedMetadataOperands, [OpaqueModule, :string, :pointer], :void
+  
+  # Add an operand to named metadata.
+  # 
+  # @see llvm::Module::getNamedMetadata()
+  # @see llvm::MDNode::addOperand()
+  # 
+  # @method add_named_metadata_operand(m, name, val)
+  # @param [OpaqueModule] m 
+  # @param [String] name 
+  # @param [OpaqueValue] val 
+  # @return [nil] 
+  # @scope class
+  attach_function :add_named_metadata_operand, :LLVMAddNamedMetadataOperand, [OpaqueModule, :string, OpaqueValue], :void
+  
+  # Add a function to a module under a specified name.
+  # 
+  # @see llvm::Function::Create()
+  # 
+  # @method add_function(m, name, function_ty)
+  # @param [OpaqueModule] m 
+  # @param [String] name 
+  # @param [OpaqueType] function_ty 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :add_function, :LLVMAddFunction, [OpaqueModule, :string, OpaqueType], OpaqueValue
+  
+  # Obtain a Function value from a Module by its name.
+  # 
+  # The returned value corresponds to a llvm::Function value.
+  # 
+  # @see llvm::Module::getFunction()
+  # 
+  # @method get_named_function(m, name)
+  # @param [OpaqueModule] m 
+  # @param [String] name 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :get_named_function, :LLVMGetNamedFunction, [OpaqueModule, :string], OpaqueValue
+  
+  # Obtain an iterator to the first Function in a Module.
+  # 
+  # @see llvm::Module::begin()
+  # 
+  # @method get_first_function(m)
+  # @param [OpaqueModule] m 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :get_first_function, :LLVMGetFirstFunction, [OpaqueModule], OpaqueValue
+  
+  # Obtain an iterator to the last Function in a Module.
+  # 
+  # @see llvm::Module::end()
+  # 
+  # @method get_last_function(m)
+  # @param [OpaqueModule] m 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :get_last_function, :LLVMGetLastFunction, [OpaqueModule], OpaqueValue
+  
+  # Advance a Function iterator to the next Function.
+  # 
+  # Returns NULL if the iterator was already at the end and there are no more
+  # functions.
+  # 
+  # @method get_next_function(fn)
+  # @param [OpaqueValue] fn 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :get_next_function, :LLVMGetNextFunction, [OpaqueValue], OpaqueValue
+  
+  # Decrement a Function iterator to the previous Function.
+  # 
+  # Returns NULL if the iterator was already at the beginning and there are
+  # no previous functions.
+  # 
+  # @method get_previous_function(fn)
+  # @param [OpaqueValue] fn 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :get_previous_function, :LLVMGetPreviousFunction, [OpaqueValue], OpaqueValue
+  
+  # Obtain the enumerated type of a Type instance.
+  # 
+  # @see llvm::Type:getTypeID()
+  # 
+  # @method get_type_kind(ty)
+  # @param [OpaqueType] ty 
+  # @return [Symbol from _enum_type_kind_] 
+  # @scope class
+  attach_function :get_type_kind, :LLVMGetTypeKind, [OpaqueType], :type_kind
+  
+  # Whether the type has a known size.
+  # 
+  # Things that don't have a size are abstract types, labels, and void.a
+  # 
+  # @see llvm::Type::isSized()
+  # 
+  # @method type_is_sized(ty)
+  # @param [OpaqueType] ty 
+  # @return [Integer] 
+  # @scope class
+  attach_function :type_is_sized, :LLVMTypeIsSized, [OpaqueType], :int
+  
+  # Obtain the context to which this type instance is associated.
+  # 
+  # @see llvm::Type::getContext()
   # 
   # @method get_type_context(ty)
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @return [FFI::Pointer(ContextRef)] 
+  # @param [OpaqueType] ty 
+  # @return [OpaqueContext] 
   # @scope class
-  attach_function :get_type_context, :LLVMGetTypeContext, [:pointer], :pointer
-
-  # Operations on integer types
+  attach_function :get_type_context, :LLVMGetTypeContext, [OpaqueType], OpaqueContext
+  
+  # Obtain an integer type from a context with specified bit width.
   # 
   # @method int1_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int1_type_in_context, :LLVMInt1TypeInContext, [:pointer], :pointer
-
+  attach_function :int1_type_in_context, :LLVMInt1TypeInContext, [OpaqueContext], OpaqueType
+  
   # (Not documented)
   # 
   # @method int8_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int8_type_in_context, :LLVMInt8TypeInContext, [:pointer], :pointer
-
+  attach_function :int8_type_in_context, :LLVMInt8TypeInContext, [OpaqueContext], OpaqueType
+  
   # (Not documented)
   # 
   # @method int16_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int16_type_in_context, :LLVMInt16TypeInContext, [:pointer], :pointer
-
+  attach_function :int16_type_in_context, :LLVMInt16TypeInContext, [OpaqueContext], OpaqueType
+  
   # (Not documented)
   # 
   # @method int32_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int32_type_in_context, :LLVMInt32TypeInContext, [:pointer], :pointer
-
+  attach_function :int32_type_in_context, :LLVMInt32TypeInContext, [OpaqueContext], OpaqueType
+  
   # (Not documented)
   # 
   # @method int64_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int64_type_in_context, :LLVMInt64TypeInContext, [:pointer], :pointer
-
+  attach_function :int64_type_in_context, :LLVMInt64TypeInContext, [OpaqueContext], OpaqueType
+  
   # (Not documented)
   # 
   # @method int_type_in_context(c, num_bits)
-  # @param [FFI::Pointer(ContextRef)] c 
+  # @param [OpaqueContext] c 
   # @param [Integer] num_bits 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int_type_in_context, :LLVMIntTypeInContext, [:pointer, :uint], :pointer
-
-  # (Not documented)
+  attach_function :int_type_in_context, :LLVMIntTypeInContext, [OpaqueContext, :uint], OpaqueType
+  
+  # Obtain an integer type from the global context with a specified bit
+  # width.
   # 
   # @method int1_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int1_type, :LLVMInt1Type, [], :pointer
-
+  attach_function :int1_type, :LLVMInt1Type, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method int8_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int8_type, :LLVMInt8Type, [], :pointer
-
+  attach_function :int8_type, :LLVMInt8Type, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method int16_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int16_type, :LLVMInt16Type, [], :pointer
-
+  attach_function :int16_type, :LLVMInt16Type, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method int32_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int32_type, :LLVMInt32Type, [], :pointer
-
+  attach_function :int32_type, :LLVMInt32Type, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method int64_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int64_type, :LLVMInt64Type, [], :pointer
-
+  attach_function :int64_type, :LLVMInt64Type, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method int_type(num_bits)
   # @param [Integer] num_bits 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :int_type, :LLVMIntType, [:uint], :pointer
-
+  attach_function :int_type, :LLVMIntType, [:uint], OpaqueType
+  
   # (Not documented)
   # 
   # @method get_int_type_width(integer_ty)
-  # @param [FFI::Pointer(TypeRef)] integer_ty 
+  # @param [OpaqueType] integer_ty 
   # @return [Integer] 
   # @scope class
-  attach_function :get_int_type_width, :LLVMGetIntTypeWidth, [:pointer], :uint
-
-  # Operations on real types
+  attach_function :get_int_type_width, :LLVMGetIntTypeWidth, [OpaqueType], :uint
+  
+  # Obtain a 16-bit floating point type from a context.
+  # 
+  # @method half_type_in_context(c)
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
+  # @scope class
+  attach_function :half_type_in_context, :LLVMHalfTypeInContext, [OpaqueContext], OpaqueType
+  
+  # Obtain a 32-bit floating point type from a context.
   # 
   # @method float_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :float_type_in_context, :LLVMFloatTypeInContext, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :float_type_in_context, :LLVMFloatTypeInContext, [OpaqueContext], OpaqueType
+  
+  # Obtain a 64-bit floating point type from a context.
   # 
   # @method double_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :double_type_in_context, :LLVMDoubleTypeInContext, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :double_type_in_context, :LLVMDoubleTypeInContext, [OpaqueContext], OpaqueType
+  
+  # Obtain a 80-bit floating point type (X87) from a context.
   # 
   # @method x86fp80_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :x86fp80_type_in_context, :LLVMX86FP80TypeInContext, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :x86fp80_type_in_context, :LLVMX86FP80TypeInContext, [OpaqueContext], OpaqueType
+  
+  # Obtain a 128-bit floating point type (112-bit mantissa) from a
+  # context.
   # 
   # @method fp128_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :fp128_type_in_context, :LLVMFP128TypeInContext, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :fp128_type_in_context, :LLVMFP128TypeInContext, [OpaqueContext], OpaqueType
+  
+  # Obtain a 128-bit floating point type (two 64-bits) from a context.
   # 
   # @method ppcfp128_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :ppcfp128_type_in_context, :LLVMPPCFP128TypeInContext, [:pointer], :pointer
-
+  attach_function :ppcfp128_type_in_context, :LLVMPPCFP128TypeInContext, [OpaqueContext], OpaqueType
+  
+  # Obtain a floating point type from the global context.
+  # 
+  # These map to the functions in this group of the same name.
+  # 
+  # @method half_type()
+  # @return [OpaqueType] 
+  # @scope class
+  attach_function :half_type, :LLVMHalfType, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method float_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :float_type, :LLVMFloatType, [], :pointer
-
+  attach_function :float_type, :LLVMFloatType, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method double_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :double_type, :LLVMDoubleType, [], :pointer
-
+  attach_function :double_type, :LLVMDoubleType, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method x86fp80_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :x86fp80_type, :LLVMX86FP80Type, [], :pointer
-
+  attach_function :x86fp80_type, :LLVMX86FP80Type, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method fp128_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :fp128_type, :LLVMFP128Type, [], :pointer
-
+  attach_function :fp128_type, :LLVMFP128Type, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method ppcfp128_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :ppcfp128_type, :LLVMPPCFP128Type, [], :pointer
-
-  # Operations on function types
+  attach_function :ppcfp128_type, :LLVMPPCFP128Type, [], OpaqueType
+  
+  # Obtain a function type consisting of a specified signature.
+  # 
+  # The function is defined as a tuple of a return Type, a list of
+  # parameter types, and whether the function is variadic.
   # 
   # @method function_type(return_type, param_types, param_count, is_var_arg)
-  # @param [FFI::Pointer(TypeRef)] return_type 
+  # @param [OpaqueType] return_type 
   # @param [FFI::Pointer(*TypeRef)] param_types 
   # @param [Integer] param_count 
   # @param [Integer] is_var_arg 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :function_type, :LLVMFunctionType, [:pointer, :pointer, :uint, :int], :pointer
-
-  # (Not documented)
+  attach_function :function_type, :LLVMFunctionType, [OpaqueType, :pointer, :uint, :int], OpaqueType
+  
+  # Returns whether a function type is variadic.
   # 
   # @method is_function_var_arg(function_ty)
-  # @param [FFI::Pointer(TypeRef)] function_ty 
+  # @param [OpaqueType] function_ty 
   # @return [Integer] 
   # @scope class
-  attach_function :is_function_var_arg, :LLVMIsFunctionVarArg, [:pointer], :int
-
-  # (Not documented)
+  attach_function :is_function_var_arg, :LLVMIsFunctionVarArg, [OpaqueType], :int
+  
+  # Obtain the Type this function Type returns.
   # 
   # @method get_return_type(function_ty)
-  # @param [FFI::Pointer(TypeRef)] function_ty 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueType] function_ty 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :get_return_type, :LLVMGetReturnType, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_return_type, :LLVMGetReturnType, [OpaqueType], OpaqueType
+  
+  # Obtain the number of parameters this function accepts.
   # 
   # @method count_param_types(function_ty)
-  # @param [FFI::Pointer(TypeRef)] function_ty 
+  # @param [OpaqueType] function_ty 
   # @return [Integer] 
   # @scope class
-  attach_function :count_param_types, :LLVMCountParamTypes, [:pointer], :uint
-
-  # (Not documented)
+  attach_function :count_param_types, :LLVMCountParamTypes, [OpaqueType], :uint
+  
+  # Obtain the types of a function's parameters.
+  # 
+  # The Dest parameter should point to a pre-allocated array of
+  # LLVMTypeRef at least LLVMCountParamTypes() large. On return, the
+  # first LLVMCountParamTypes() entries in the array will be populated
+  # with LLVMTypeRef instances.
+  # 
+  # @param FunctionTy The function type to operate on.
+  # @param Dest Memory address of an array to be filled with result.
   # 
   # @method get_param_types(function_ty, dest)
-  # @param [FFI::Pointer(TypeRef)] function_ty 
+  # @param [OpaqueType] function_ty 
   # @param [FFI::Pointer(*TypeRef)] dest 
   # @return [nil] 
   # @scope class
-  attach_function :get_param_types, :LLVMGetParamTypes, [:pointer, :pointer], :void
-
-  # Operations on struct types
+  attach_function :get_param_types, :LLVMGetParamTypes, [OpaqueType, :pointer], :void
+  
+  # Create a new structure type in a context.
+  # 
+  # A structure is specified by a list of inner elements/types and
+  # whether these can be packed together.
+  # 
+  # @see llvm::StructType::create()
   # 
   # @method struct_type_in_context(c, element_types, element_count, packed)
-  # @param [FFI::Pointer(ContextRef)] c 
+  # @param [OpaqueContext] c 
   # @param [FFI::Pointer(*TypeRef)] element_types 
   # @param [Integer] element_count 
   # @param [Integer] packed 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :struct_type_in_context, :LLVMStructTypeInContext, [:pointer, :pointer, :uint, :int], :pointer
-
-  # (Not documented)
+  attach_function :struct_type_in_context, :LLVMStructTypeInContext, [OpaqueContext, :pointer, :uint, :int], OpaqueType
+  
+  # Create a new structure type in the global context.
+  # 
+  # @see llvm::StructType::create()
   # 
   # @method struct_type(element_types, element_count, packed)
   # @param [FFI::Pointer(*TypeRef)] element_types 
   # @param [Integer] element_count 
   # @param [Integer] packed 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :struct_type, :LLVMStructType, [:pointer, :uint, :int], :pointer
-
-  # (Not documented)
+  attach_function :struct_type, :LLVMStructType, [:pointer, :uint, :int], OpaqueType
+  
+  # Create an empty structure in a context having a specified name.
+  # 
+  # @see llvm::StructType::create()
   # 
   # @method struct_create_named(c, name)
-  # @param [FFI::Pointer(ContextRef)] c 
+  # @param [OpaqueContext] c 
   # @param [String] name 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :struct_create_named, :LLVMStructCreateNamed, [:pointer, :string], :pointer
-
-  # (Not documented)
+  attach_function :struct_create_named, :LLVMStructCreateNamed, [OpaqueContext, :string], OpaqueType
+  
+  # Obtain the name of a structure.
+  # 
+  # @see llvm::StructType::getName()
   # 
   # @method get_struct_name(ty)
-  # @param [FFI::Pointer(TypeRef)] ty 
+  # @param [OpaqueType] ty 
   # @return [String] 
   # @scope class
-  attach_function :get_struct_name, :LLVMGetStructName, [:pointer], :string
-
-  # (Not documented)
+  attach_function :get_struct_name, :LLVMGetStructName, [OpaqueType], :string
+  
+  # Set the contents of a structure type.
+  # 
+  # @see llvm::StructType::setBody()
   # 
   # @method struct_set_body(struct_ty, element_types, element_count, packed)
-  # @param [FFI::Pointer(TypeRef)] struct_ty 
+  # @param [OpaqueType] struct_ty 
   # @param [FFI::Pointer(*TypeRef)] element_types 
   # @param [Integer] element_count 
   # @param [Integer] packed 
   # @return [nil] 
   # @scope class
-  attach_function :struct_set_body, :LLVMStructSetBody, [:pointer, :pointer, :uint, :int], :void
-
-  # (Not documented)
+  attach_function :struct_set_body, :LLVMStructSetBody, [OpaqueType, :pointer, :uint, :int], :void
+  
+  # Get the number of elements defined inside the structure.
+  # 
+  # @see llvm::StructType::getNumElements()
   # 
   # @method count_struct_element_types(struct_ty)
-  # @param [FFI::Pointer(TypeRef)] struct_ty 
+  # @param [OpaqueType] struct_ty 
   # @return [Integer] 
   # @scope class
-  attach_function :count_struct_element_types, :LLVMCountStructElementTypes, [:pointer], :uint
-
-  # (Not documented)
+  attach_function :count_struct_element_types, :LLVMCountStructElementTypes, [OpaqueType], :uint
+  
+  # Get the elements within a structure.
+  # 
+  # The function is passed the address of a pre-allocated array of
+  # LLVMTypeRef at least LLVMCountStructElementTypes() long. After
+  # invocation, this array will be populated with the structure's
+  # elements. The objects in the destination array will have a lifetime
+  # of the structure type itself, which is the lifetime of the context it
+  # is contained in.
   # 
   # @method get_struct_element_types(struct_ty, dest)
-  # @param [FFI::Pointer(TypeRef)] struct_ty 
+  # @param [OpaqueType] struct_ty 
   # @param [FFI::Pointer(*TypeRef)] dest 
   # @return [nil] 
   # @scope class
-  attach_function :get_struct_element_types, :LLVMGetStructElementTypes, [:pointer, :pointer], :void
-
-  # (Not documented)
+  attach_function :get_struct_element_types, :LLVMGetStructElementTypes, [OpaqueType, :pointer], :void
+  
+  # Determine whether a structure is packed.
+  # 
+  # @see llvm::StructType::isPacked()
   # 
   # @method is_packed_struct(struct_ty)
-  # @param [FFI::Pointer(TypeRef)] struct_ty 
+  # @param [OpaqueType] struct_ty 
   # @return [Integer] 
   # @scope class
-  attach_function :is_packed_struct, :LLVMIsPackedStruct, [:pointer], :int
-
-  # (Not documented)
+  attach_function :is_packed_struct, :LLVMIsPackedStruct, [OpaqueType], :int
+  
+  # Determine whether a structure is opaque.
+  # 
+  # @see llvm::StructType::isOpaque()
   # 
   # @method is_opaque_struct(struct_ty)
-  # @param [FFI::Pointer(TypeRef)] struct_ty 
+  # @param [OpaqueType] struct_ty 
   # @return [Integer] 
   # @scope class
-  attach_function :is_opaque_struct, :LLVMIsOpaqueStruct, [:pointer], :int
-
-  # (Not documented)
+  attach_function :is_opaque_struct, :LLVMIsOpaqueStruct, [OpaqueType], :int
+  
+  # Obtain the type of elements within a sequential type.
   # 
-  # @method get_type_by_name(m, name)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @param [String] name 
-  # @return [FFI::Pointer(TypeRef)] 
-  # @scope class
-  attach_function :get_type_by_name, :LLVMGetTypeByName, [:pointer, :string], :pointer
-
-  # Operations on array, pointer, and vector types (sequence types)
+  # This works on array, vector, and pointer types.
   # 
-  # @method array_type(element_type, element_count)
-  # @param [FFI::Pointer(TypeRef)] element_type 
-  # @param [Integer] element_count 
-  # @return [FFI::Pointer(TypeRef)] 
-  # @scope class
-  attach_function :array_type, :LLVMArrayType, [:pointer, :uint], :pointer
-
-  # (Not documented)
-  # 
-  # @method pointer_type(element_type, address_space)
-  # @param [FFI::Pointer(TypeRef)] element_type 
-  # @param [Integer] address_space 
-  # @return [FFI::Pointer(TypeRef)] 
-  # @scope class
-  attach_function :pointer_type, :LLVMPointerType, [:pointer, :uint], :pointer
-
-  # (Not documented)
-  # 
-  # @method vector_type(element_type, element_count)
-  # @param [FFI::Pointer(TypeRef)] element_type 
-  # @param [Integer] element_count 
-  # @return [FFI::Pointer(TypeRef)] 
-  # @scope class
-  attach_function :vector_type, :LLVMVectorType, [:pointer, :uint], :pointer
-
-  # (Not documented)
+  # @see llvm::SequentialType::getElementType()
   # 
   # @method get_element_type(ty)
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueType] ty 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :get_element_type, :LLVMGetElementType, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_element_type, :LLVMGetElementType, [OpaqueType], OpaqueType
+  
+  # Create a fixed size array type that refers to a specific type.
+  # 
+  # The created type will exist in the context that its element type
+  # exists in.
+  # 
+  # @see llvm::ArrayType::get()
+  # 
+  # @method array_type(element_type, element_count)
+  # @param [OpaqueType] element_type 
+  # @param [Integer] element_count 
+  # @return [OpaqueType] 
+  # @scope class
+  attach_function :array_type, :LLVMArrayType, [OpaqueType, :uint], OpaqueType
+  
+  # Obtain the length of an array type.
+  # 
+  # This only works on types that represent arrays.
+  # 
+  # @see llvm::ArrayType::getNumElements()
   # 
   # @method get_array_length(array_ty)
-  # @param [FFI::Pointer(TypeRef)] array_ty 
+  # @param [OpaqueType] array_ty 
   # @return [Integer] 
   # @scope class
-  attach_function :get_array_length, :LLVMGetArrayLength, [:pointer], :uint
-
-  # (Not documented)
+  attach_function :get_array_length, :LLVMGetArrayLength, [OpaqueType], :uint
+  
+  # Create a pointer type that points to a defined type.
+  # 
+  # The created type will exist in the context that its pointee type
+  # exists in.
+  # 
+  # @see llvm::PointerType::get()
+  # 
+  # @method pointer_type(element_type, address_space)
+  # @param [OpaqueType] element_type 
+  # @param [Integer] address_space 
+  # @return [OpaqueType] 
+  # @scope class
+  attach_function :pointer_type, :LLVMPointerType, [OpaqueType, :uint], OpaqueType
+  
+  # Obtain the address space of a pointer type.
+  # 
+  # This only works on types that represent pointers.
+  # 
+  # @see llvm::PointerType::getAddressSpace()
   # 
   # @method get_pointer_address_space(pointer_ty)
-  # @param [FFI::Pointer(TypeRef)] pointer_ty 
+  # @param [OpaqueType] pointer_ty 
   # @return [Integer] 
   # @scope class
-  attach_function :get_pointer_address_space, :LLVMGetPointerAddressSpace, [:pointer], :uint
-
-  # (Not documented)
+  attach_function :get_pointer_address_space, :LLVMGetPointerAddressSpace, [OpaqueType], :uint
+  
+  # Create a vector type that contains a defined type and has a specific
+  # number of elements.
+  # 
+  # The created type will exist in the context thats its element type
+  # exists in.
+  # 
+  # @see llvm::VectorType::get()
+  # 
+  # @method vector_type(element_type, element_count)
+  # @param [OpaqueType] element_type 
+  # @param [Integer] element_count 
+  # @return [OpaqueType] 
+  # @scope class
+  attach_function :vector_type, :LLVMVectorType, [OpaqueType, :uint], OpaqueType
+  
+  # Obtain the number of elements in a vector type.
+  # 
+  # This only works on types that represent vectors.
+  # 
+  # @see llvm::VectorType::getNumElements()
   # 
   # @method get_vector_size(vector_ty)
-  # @param [FFI::Pointer(TypeRef)] vector_ty 
+  # @param [OpaqueType] vector_ty 
   # @return [Integer] 
   # @scope class
-  attach_function :get_vector_size, :LLVMGetVectorSize, [:pointer], :uint
-
-  # Operations on other types
+  attach_function :get_vector_size, :LLVMGetVectorSize, [OpaqueType], :uint
+  
+  # Create a void type in a context.
   # 
   # @method void_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :void_type_in_context, :LLVMVoidTypeInContext, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :void_type_in_context, :LLVMVoidTypeInContext, [OpaqueContext], OpaqueType
+  
+  # Create a label type in a context.
   # 
   # @method label_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :label_type_in_context, :LLVMLabelTypeInContext, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :label_type_in_context, :LLVMLabelTypeInContext, [OpaqueContext], OpaqueType
+  
+  # Create a X86 MMX type in a context.
   # 
   # @method x86mmx_type_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :x86mmx_type_in_context, :LLVMX86MMXTypeInContext, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :x86mmx_type_in_context, :LLVMX86MMXTypeInContext, [OpaqueContext], OpaqueType
+  
+  # These are similar to the above functions except they operate on the
+  # global context.
   # 
   # @method void_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :void_type, :LLVMVoidType, [], :pointer
-
+  attach_function :void_type, :LLVMVoidType, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method label_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :label_type, :LLVMLabelType, [], :pointer
-
+  attach_function :label_type, :LLVMLabelType, [], OpaqueType
+  
   # (Not documented)
   # 
   # @method x86mmx_type()
-  # @return [FFI::Pointer(TypeRef)] 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :x86mmx_type, :LLVMX86MMXType, [], :pointer
-
-  # Operations on all values
+  attach_function :x86mmx_type, :LLVMX86MMXType, [], OpaqueType
+  
+  # Obtain the type of a value.
+  # 
+  # @see llvm::Value::getType()
   # 
   # @method type_of(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(TypeRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueType] 
   # @scope class
-  attach_function :type_of, :LLVMTypeOf, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :type_of, :LLVMTypeOf, [OpaqueValue], OpaqueType
+  
+  # Obtain the string name of a value.
+  # 
+  # @see llvm::Value::getName()
   # 
   # @method get_value_name(val)
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @param [OpaqueValue] val 
   # @return [String] 
   # @scope class
-  attach_function :get_value_name, :LLVMGetValueName, [:pointer], :string
-
-  # (Not documented)
+  attach_function :get_value_name, :LLVMGetValueName, [OpaqueValue], :string
+  
+  # Set the string name of a value.
+  # 
+  # @see llvm::Value::setName()
   # 
   # @method set_value_name(val, name)
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @param [OpaqueValue] val 
   # @param [String] name 
   # @return [nil] 
   # @scope class
-  attach_function :set_value_name, :LLVMSetValueName, [:pointer, :string], :void
-
-  # (Not documented)
+  attach_function :set_value_name, :LLVMSetValueName, [OpaqueValue, :string], :void
+  
+  # Dump a representation of a value to stderr.
+  # 
+  # @see llvm::Value::dump()
   # 
   # @method dump_value(val)
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @param [OpaqueValue] val 
   # @return [nil] 
   # @scope class
-  attach_function :dump_value, :LLVMDumpValue, [:pointer], :void
-
-  # (Not documented)
+  attach_function :dump_value, :LLVMDumpValue, [OpaqueValue], :void
+  
+  # Replace all uses of a value with another one.
+  # 
+  # @see llvm::Value::replaceAllUsesWith()
   # 
   # @method replace_all_uses_with(old_val, new_val)
-  # @param [FFI::Pointer(ValueRef)] old_val 
-  # @param [FFI::Pointer(ValueRef)] new_val 
+  # @param [OpaqueValue] old_val 
+  # @param [OpaqueValue] new_val 
   # @return [nil] 
   # @scope class
-  attach_function :replace_all_uses_with, :LLVMReplaceAllUsesWith, [:pointer, :pointer], :void
-
-  # (Not documented)
+  attach_function :replace_all_uses_with, :LLVMReplaceAllUsesWith, [OpaqueValue, OpaqueValue], :void
+  
+  # Determine whether the specified constant instance is constant.
   # 
-  # @method has_metadata(val)
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @method is_constant(val)
+  # @param [OpaqueValue] val 
   # @return [Integer] 
   # @scope class
-  attach_function :has_metadata, :LLVMHasMetadata, [:pointer], :int
-
-  # (Not documented)
+  attach_function :is_constant, :LLVMIsConstant, [OpaqueValue], :int
+  
+  # Determine whether a value instance is undefined.
   # 
-  # @method get_metadata(val, kind_id)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [Integer] kind_id 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @method is_undef(val)
+  # @param [OpaqueValue] val 
+  # @return [Integer] 
   # @scope class
-  attach_function :get_metadata, :LLVMGetMetadata, [:pointer, :uint], :pointer
-
-  # (Not documented)
-  # 
-  # @method set_metadata(val, kind_id, node)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [Integer] kind_id 
-  # @param [FFI::Pointer(ValueRef)] node 
-  # @return [nil] 
-  # @scope class
-  attach_function :set_metadata, :LLVMSetMetadata, [:pointer, :uint, :pointer], :void
-
+  attach_function :is_undef, :LLVMIsUndef, [OpaqueValue], :int
+  
   # (Not documented)
   # 
   # @method is_a_argument(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_argument, :LLVMIsAArgument, [:pointer], :pointer
-
+  attach_function :is_a_argument, :LLVMIsAArgument, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_basic_block(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_basic_block, :LLVMIsABasicBlock, [:pointer], :pointer
-
+  attach_function :is_a_basic_block, :LLVMIsABasicBlock, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_inline_asm(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_inline_asm, :LLVMIsAInlineAsm, [:pointer], :pointer
-
+  attach_function :is_a_inline_asm, :LLVMIsAInlineAsm, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_amd_node(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_amd_node, :LLVMIsAMDNode, [:pointer], :pointer
-
+  attach_function :is_amd_node, :LLVMIsAMDNode, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_amd_string(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_amd_string, :LLVMIsAMDString, [:pointer], :pointer
-
+  attach_function :is_amd_string, :LLVMIsAMDString, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_user(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_user, :LLVMIsAUser, [:pointer], :pointer
-
+  attach_function :is_a_user, :LLVMIsAUser, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_constant(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_constant, :LLVMIsAConstant, [:pointer], :pointer
-
+  attach_function :is_a_constant, :LLVMIsAConstant, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_block_address(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_block_address, :LLVMIsABlockAddress, [:pointer], :pointer
-
+  attach_function :is_a_block_address, :LLVMIsABlockAddress, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_constant_aggregate_zero(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_constant_aggregate_zero, :LLVMIsAConstantAggregateZero, [:pointer], :pointer
-
+  attach_function :is_a_constant_aggregate_zero, :LLVMIsAConstantAggregateZero, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_constant_array(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_constant_array, :LLVMIsAConstantArray, [:pointer], :pointer
-
+  attach_function :is_a_constant_array, :LLVMIsAConstantArray, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_constant_expr(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_constant_expr, :LLVMIsAConstantExpr, [:pointer], :pointer
-
+  attach_function :is_a_constant_expr, :LLVMIsAConstantExpr, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_constant_fp(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_constant_fp, :LLVMIsAConstantFP, [:pointer], :pointer
-
+  attach_function :is_a_constant_fp, :LLVMIsAConstantFP, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_constant_int(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_constant_int, :LLVMIsAConstantInt, [:pointer], :pointer
-
+  attach_function :is_a_constant_int, :LLVMIsAConstantInt, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_constant_pointer_null(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_constant_pointer_null, :LLVMIsAConstantPointerNull, [:pointer], :pointer
-
+  attach_function :is_a_constant_pointer_null, :LLVMIsAConstantPointerNull, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_constant_struct(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_constant_struct, :LLVMIsAConstantStruct, [:pointer], :pointer
-
+  attach_function :is_a_constant_struct, :LLVMIsAConstantStruct, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_constant_vector(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_constant_vector, :LLVMIsAConstantVector, [:pointer], :pointer
-
+  attach_function :is_a_constant_vector, :LLVMIsAConstantVector, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_global_value(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_global_value, :LLVMIsAGlobalValue, [:pointer], :pointer
-
+  attach_function :is_a_global_value, :LLVMIsAGlobalValue, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_function(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_function, :LLVMIsAFunction, [:pointer], :pointer
-
+  attach_function :is_a_function, :LLVMIsAFunction, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_global_alias(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_global_alias, :LLVMIsAGlobalAlias, [:pointer], :pointer
-
+  attach_function :is_a_global_alias, :LLVMIsAGlobalAlias, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_global_variable(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_global_variable, :LLVMIsAGlobalVariable, [:pointer], :pointer
-
+  attach_function :is_a_global_variable, :LLVMIsAGlobalVariable, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_undef_value(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_undef_value, :LLVMIsAUndefValue, [:pointer], :pointer
-
+  attach_function :is_a_undef_value, :LLVMIsAUndefValue, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_instruction(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_instruction, :LLVMIsAInstruction, [:pointer], :pointer
-
+  attach_function :is_a_instruction, :LLVMIsAInstruction, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_binary_operator(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_binary_operator, :LLVMIsABinaryOperator, [:pointer], :pointer
-
+  attach_function :is_a_binary_operator, :LLVMIsABinaryOperator, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_call_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_call_inst, :LLVMIsACallInst, [:pointer], :pointer
-
+  attach_function :is_a_call_inst, :LLVMIsACallInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_intrinsic_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_intrinsic_inst, :LLVMIsAIntrinsicInst, [:pointer], :pointer
-
+  attach_function :is_a_intrinsic_inst, :LLVMIsAIntrinsicInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_dbg_info_intrinsic(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_dbg_info_intrinsic, :LLVMIsADbgInfoIntrinsic, [:pointer], :pointer
-
+  attach_function :is_a_dbg_info_intrinsic, :LLVMIsADbgInfoIntrinsic, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_dbg_declare_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_dbg_declare_inst, :LLVMIsADbgDeclareInst, [:pointer], :pointer
-
-  # (Not documented)
-  # 
-  # @method is_aeh_exception_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :is_aeh_exception_inst, :LLVMIsAEHExceptionInst, [:pointer], :pointer
-
-  # (Not documented)
-  # 
-  # @method is_aeh_selector_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :is_aeh_selector_inst, :LLVMIsAEHSelectorInst, [:pointer], :pointer
-
+  attach_function :is_a_dbg_declare_inst, :LLVMIsADbgDeclareInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_mem_intrinsic(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_mem_intrinsic, :LLVMIsAMemIntrinsic, [:pointer], :pointer
-
+  attach_function :is_a_mem_intrinsic, :LLVMIsAMemIntrinsic, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_mem_cpy_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_mem_cpy_inst, :LLVMIsAMemCpyInst, [:pointer], :pointer
-
+  attach_function :is_a_mem_cpy_inst, :LLVMIsAMemCpyInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_mem_move_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_mem_move_inst, :LLVMIsAMemMoveInst, [:pointer], :pointer
-
+  attach_function :is_a_mem_move_inst, :LLVMIsAMemMoveInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_mem_set_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_mem_set_inst, :LLVMIsAMemSetInst, [:pointer], :pointer
-
+  attach_function :is_a_mem_set_inst, :LLVMIsAMemSetInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_cmp_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_cmp_inst, :LLVMIsACmpInst, [:pointer], :pointer
-
+  attach_function :is_a_cmp_inst, :LLVMIsACmpInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_af_cmp_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_af_cmp_inst, :LLVMIsAFCmpInst, [:pointer], :pointer
-
+  attach_function :is_af_cmp_inst, :LLVMIsAFCmpInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_ai_cmp_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_ai_cmp_inst, :LLVMIsAICmpInst, [:pointer], :pointer
-
+  attach_function :is_ai_cmp_inst, :LLVMIsAICmpInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_extract_element_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_extract_element_inst, :LLVMIsAExtractElementInst, [:pointer], :pointer
-
+  attach_function :is_a_extract_element_inst, :LLVMIsAExtractElementInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_get_element_ptr_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_get_element_ptr_inst, :LLVMIsAGetElementPtrInst, [:pointer], :pointer
-
+  attach_function :is_a_get_element_ptr_inst, :LLVMIsAGetElementPtrInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_insert_element_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_insert_element_inst, :LLVMIsAInsertElementInst, [:pointer], :pointer
-
+  attach_function :is_a_insert_element_inst, :LLVMIsAInsertElementInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_insert_value_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_insert_value_inst, :LLVMIsAInsertValueInst, [:pointer], :pointer
-
+  attach_function :is_a_insert_value_inst, :LLVMIsAInsertValueInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_landing_pad_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_landing_pad_inst, :LLVMIsALandingPadInst, [:pointer], :pointer
-
+  attach_function :is_a_landing_pad_inst, :LLVMIsALandingPadInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_aphi_node(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_aphi_node, :LLVMIsAPHINode, [:pointer], :pointer
-
+  attach_function :is_aphi_node, :LLVMIsAPHINode, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_select_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_select_inst, :LLVMIsASelectInst, [:pointer], :pointer
-
+  attach_function :is_a_select_inst, :LLVMIsASelectInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_shuffle_vector_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_shuffle_vector_inst, :LLVMIsAShuffleVectorInst, [:pointer], :pointer
-
+  attach_function :is_a_shuffle_vector_inst, :LLVMIsAShuffleVectorInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_store_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_store_inst, :LLVMIsAStoreInst, [:pointer], :pointer
-
+  attach_function :is_a_store_inst, :LLVMIsAStoreInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_terminator_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_terminator_inst, :LLVMIsATerminatorInst, [:pointer], :pointer
-
+  attach_function :is_a_terminator_inst, :LLVMIsATerminatorInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_branch_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_branch_inst, :LLVMIsABranchInst, [:pointer], :pointer
-
+  attach_function :is_a_branch_inst, :LLVMIsABranchInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_indirect_br_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_indirect_br_inst, :LLVMIsAIndirectBrInst, [:pointer], :pointer
-
+  attach_function :is_a_indirect_br_inst, :LLVMIsAIndirectBrInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_invoke_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_invoke_inst, :LLVMIsAInvokeInst, [:pointer], :pointer
-
+  attach_function :is_a_invoke_inst, :LLVMIsAInvokeInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_return_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_return_inst, :LLVMIsAReturnInst, [:pointer], :pointer
-
+  attach_function :is_a_return_inst, :LLVMIsAReturnInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_switch_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_switch_inst, :LLVMIsASwitchInst, [:pointer], :pointer
-
+  attach_function :is_a_switch_inst, :LLVMIsASwitchInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_unreachable_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_unreachable_inst, :LLVMIsAUnreachableInst, [:pointer], :pointer
-
+  attach_function :is_a_unreachable_inst, :LLVMIsAUnreachableInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_resume_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_resume_inst, :LLVMIsAResumeInst, [:pointer], :pointer
-
+  attach_function :is_a_resume_inst, :LLVMIsAResumeInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_unary_instruction(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_unary_instruction, :LLVMIsAUnaryInstruction, [:pointer], :pointer
-
+  attach_function :is_a_unary_instruction, :LLVMIsAUnaryInstruction, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_alloca_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_alloca_inst, :LLVMIsAAllocaInst, [:pointer], :pointer
-
+  attach_function :is_a_alloca_inst, :LLVMIsAAllocaInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_cast_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_cast_inst, :LLVMIsACastInst, [:pointer], :pointer
-
+  attach_function :is_a_cast_inst, :LLVMIsACastInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_bit_cast_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_bit_cast_inst, :LLVMIsABitCastInst, [:pointer], :pointer
-
+  attach_function :is_a_bit_cast_inst, :LLVMIsABitCastInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_afp_ext_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_afp_ext_inst, :LLVMIsAFPExtInst, [:pointer], :pointer
-
+  attach_function :is_afp_ext_inst, :LLVMIsAFPExtInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_afp_to_si_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_afp_to_si_inst, :LLVMIsAFPToSIInst, [:pointer], :pointer
-
+  attach_function :is_afp_to_si_inst, :LLVMIsAFPToSIInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_afp_to_ui_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_afp_to_ui_inst, :LLVMIsAFPToUIInst, [:pointer], :pointer
-
+  attach_function :is_afp_to_ui_inst, :LLVMIsAFPToUIInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_afp_trunc_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_afp_trunc_inst, :LLVMIsAFPTruncInst, [:pointer], :pointer
-
+  attach_function :is_afp_trunc_inst, :LLVMIsAFPTruncInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_int_to_ptr_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_int_to_ptr_inst, :LLVMIsAIntToPtrInst, [:pointer], :pointer
-
+  attach_function :is_a_int_to_ptr_inst, :LLVMIsAIntToPtrInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_ptr_to_int_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_ptr_to_int_inst, :LLVMIsAPtrToIntInst, [:pointer], :pointer
-
+  attach_function :is_a_ptr_to_int_inst, :LLVMIsAPtrToIntInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_as_ext_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_as_ext_inst, :LLVMIsASExtInst, [:pointer], :pointer
-
+  attach_function :is_as_ext_inst, :LLVMIsASExtInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_asi_to_fp_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_asi_to_fp_inst, :LLVMIsASIToFPInst, [:pointer], :pointer
-
+  attach_function :is_asi_to_fp_inst, :LLVMIsASIToFPInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_trunc_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_trunc_inst, :LLVMIsATruncInst, [:pointer], :pointer
-
+  attach_function :is_a_trunc_inst, :LLVMIsATruncInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_aui_to_fp_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_aui_to_fp_inst, :LLVMIsAUIToFPInst, [:pointer], :pointer
-
+  attach_function :is_aui_to_fp_inst, :LLVMIsAUIToFPInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_az_ext_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_az_ext_inst, :LLVMIsAZExtInst, [:pointer], :pointer
-
+  attach_function :is_az_ext_inst, :LLVMIsAZExtInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_extract_value_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_extract_value_inst, :LLVMIsAExtractValueInst, [:pointer], :pointer
-
+  attach_function :is_a_extract_value_inst, :LLVMIsAExtractValueInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_a_load_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_a_load_inst, :LLVMIsALoadInst, [:pointer], :pointer
-
+  attach_function :is_a_load_inst, :LLVMIsALoadInst, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method is_ava_arg_inst(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :is_ava_arg_inst, :LLVMIsAVAArgInst, [:pointer], :pointer
-
-  # Operations on Uses
+  attach_function :is_ava_arg_inst, :LLVMIsAVAArgInst, [OpaqueValue], OpaqueValue
+  
+  # Obtain the first use of a value.
+  # 
+  # Uses are obtained in an iterator fashion. First, call this function
+  # to obtain a reference to the first use. Then, call LLVMGetNextUse()
+  # on that instance and all subsequently obtained instances untl
+  # LLVMGetNextUse() returns NULL.
+  # 
+  # @see llvm::Value::use_begin()
   # 
   # @method get_first_use(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(UseRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueUse] 
   # @scope class
-  attach_function :get_first_use, :LLVMGetFirstUse, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_first_use, :LLVMGetFirstUse, [OpaqueValue], OpaqueUse
+  
+  # Obtain the next use of a value.
+  # 
+  # This effectively advances the iterator. It returns NULL if you are on
+  # the final use and no more are available.
   # 
   # @method get_next_use(u)
-  # @param [FFI::Pointer(UseRef)] u 
-  # @return [FFI::Pointer(UseRef)] 
+  # @param [OpaqueUse] u 
+  # @return [OpaqueUse] 
   # @scope class
-  attach_function :get_next_use, :LLVMGetNextUse, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_next_use, :LLVMGetNextUse, [OpaqueUse], OpaqueUse
+  
+  # Obtain the user value for a user.
+  # 
+  # The returned value corresponds to a llvm::User type.
+  # 
+  # @see llvm::Use::getUser()
   # 
   # @method get_user(u)
-  # @param [FFI::Pointer(UseRef)] u 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueUse] u 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_user, :LLVMGetUser, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_user, :LLVMGetUser, [OpaqueUse], OpaqueValue
+  
+  # Obtain the value this use corresponds to.
+  # 
+  # @see llvm::Use::get().
   # 
   # @method get_used_value(u)
-  # @param [FFI::Pointer(UseRef)] u 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueUse] u 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_used_value, :LLVMGetUsedValue, [:pointer], :pointer
-
-  # Operations on Users
+  attach_function :get_used_value, :LLVMGetUsedValue, [OpaqueUse], OpaqueValue
+  
+  # Obtain an operand at a specific index in a llvm::User value.
+  # 
+  # @see llvm::User::getOperand()
   # 
   # @method get_operand(val, index)
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @param [OpaqueValue] val 
   # @param [Integer] index 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_operand, :LLVMGetOperand, [:pointer, :uint], :pointer
-
-  # (Not documented)
+  attach_function :get_operand, :LLVMGetOperand, [OpaqueValue, :uint], OpaqueValue
+  
+  # Set an operand at a specific index in a llvm::User value.
+  # 
+  # @see llvm::User::setOperand()
   # 
   # @method set_operand(user, index, val)
-  # @param [FFI::Pointer(ValueRef)] user 
+  # @param [OpaqueValue] user 
   # @param [Integer] index 
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @param [OpaqueValue] val 
   # @return [nil] 
   # @scope class
-  attach_function :set_operand, :LLVMSetOperand, [:pointer, :uint, :pointer], :void
-
-  # (Not documented)
+  attach_function :set_operand, :LLVMSetOperand, [OpaqueValue, :uint, OpaqueValue], :void
+  
+  # Obtain the number of operands in a llvm::User value.
+  # 
+  # @see llvm::User::getNumOperands()
   # 
   # @method get_num_operands(val)
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @param [OpaqueValue] val 
   # @return [Integer] 
   # @scope class
-  attach_function :get_num_operands, :LLVMGetNumOperands, [:pointer], :int
-
-  # Operations on constants of any type
+  attach_function :get_num_operands, :LLVMGetNumOperands, [OpaqueValue], :int
+  
+  # Obtain a constant value referring to the null instance of a type.
+  # 
+  # @see llvm::Constant::getNullValue()
   # 
   # @method const_null(ty)
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueType] ty 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_null, :LLVMConstNull, [:pointer], :pointer
-
-  # all zeroes
+  attach_function :const_null, :LLVMConstNull, [OpaqueType], OpaqueValue
+  
+  # Obtain a constant value referring to the instance of a type
+  # consisting of all ones.
+  # 
+  # This is only valid for integer types.
+  # 
+  # @see llvm::Constant::getAllOnesValue()
   # 
   # @method const_all_ones(ty)
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueType] ty 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_all_ones, :LLVMConstAllOnes, [:pointer], :pointer
-
-  # only for int/vector
+  attach_function :const_all_ones, :LLVMConstAllOnes, [OpaqueType], OpaqueValue
+  
+  # Obtain a constant value referring to an undefined value of a type.
+  # 
+  # @see llvm::UndefValue::get()
   # 
   # @method get_undef(ty)
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueType] ty 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_undef, :LLVMGetUndef, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_undef, :LLVMGetUndef, [OpaqueType], OpaqueValue
+  
+  # Determine whether a value instance is null.
   # 
-  # @method is_constant(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [Integer] 
-  # @scope class
-  attach_function :is_constant, :LLVMIsConstant, [:pointer], :int
-
-  # (Not documented)
+  # @see llvm::Constant::isNullValue()
   # 
   # @method is_null(val)
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @param [OpaqueValue] val 
   # @return [Integer] 
   # @scope class
-  attach_function :is_null, :LLVMIsNull, [:pointer], :int
-
-  # (Not documented)
-  # 
-  # @method is_undef(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [Integer] 
-  # @scope class
-  attach_function :is_undef, :LLVMIsUndef, [:pointer], :int
-
-  # (Not documented)
+  attach_function :is_null, :LLVMIsNull, [OpaqueValue], :int
+  
+  # Obtain a constant that is a constant pointer pointing to NULL for a
+  # specified type.
   # 
   # @method const_pointer_null(ty)
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueType] ty 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_pointer_null, :LLVMConstPointerNull, [:pointer], :pointer
-
-  # Operations on metadata
+  attach_function :const_pointer_null, :LLVMConstPointerNull, [OpaqueType], OpaqueValue
+  
+  # Obtain a constant value for an integer type.
   # 
-  # @method md_string_in_context(c, str, s_len)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @param [String] str 
-  # @param [Integer] s_len 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :md_string_in_context, :LLVMMDStringInContext, [:pointer, :string, :uint], :pointer
-
-  # (Not documented)
+  # The returned value corresponds to a llvm::ConstantInt.
   # 
-  # @method md_string(str, s_len)
-  # @param [String] str 
-  # @param [Integer] s_len 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :md_string, :LLVMMDString, [:string, :uint], :pointer
-
-  # (Not documented)
+  # @see llvm::ConstantInt::get()
   # 
-  # @method md_node_in_context(c, vals, count)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @param [FFI::Pointer(*ValueRef)] vals 
-  # @param [Integer] count 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :md_node_in_context, :LLVMMDNodeInContext, [:pointer, :pointer, :uint], :pointer
-
-  # (Not documented)
-  # 
-  # @method md_node(vals, count)
-  # @param [FFI::Pointer(*ValueRef)] vals 
-  # @param [Integer] count 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :md_node, :LLVMMDNode, [:pointer, :uint], :pointer
-
-  # (Not documented)
-  # 
-  # @method get_md_string(v, len)
-  # @param [FFI::Pointer(ValueRef)] v 
-  # @param [FFI::Pointer(*UInt)] len 
-  # @return [String] 
-  # @scope class
-  attach_function :get_md_string, :LLVMGetMDString, [:pointer, :pointer], :string
-
-  # (Not documented)
-  # 
-  # @method get_named_metadata_num_operands(m, name)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @param [String] name 
-  # @return [Integer] 
-  # @scope class
-  attach_function :get_named_metadata_num_operands, :LLVMGetNamedMetadataNumOperands, [:pointer, :string], :uint
-
-  # (Not documented)
-  # 
-  # @method get_named_metadata_operands(m, name, dest)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @param [String] name 
-  # @param [FFI::Pointer(*ValueRef)] dest 
-  # @return [nil] 
-  # @scope class
-  attach_function :get_named_metadata_operands, :LLVMGetNamedMetadataOperands, [:pointer, :string, :pointer], :void
-
-  # Operations on scalar constants
+  # @param IntTy Integer type to obtain value of.
+  # @param N The value the returned instance should refer to.
+  # @param SignExtend Whether to sign extend the produced value.
   # 
   # @method const_int(int_ty, n, sign_extend)
-  # @param [FFI::Pointer(TypeRef)] int_ty 
+  # @param [OpaqueType] int_ty 
   # @param [Integer] n 
   # @param [Integer] sign_extend 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_int, :LLVMConstInt, [:pointer, :ulong_long, :int], :pointer
-
-  # (Not documented)
+  attach_function :const_int, :LLVMConstInt, [OpaqueType, :ulong_long, :int], OpaqueValue
+  
+  # Obtain a constant value for an integer of arbitrary precision.
+  # 
+  # @see llvm::ConstantInt::get()
   # 
   # @method const_int_of_arbitrary_precision(int_ty, num_words, words)
-  # @param [FFI::Pointer(TypeRef)] int_ty 
+  # @param [OpaqueType] int_ty 
   # @param [Integer] num_words 
-  # @param [FFI::Pointer(*uint64_t)] words 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [FFI::Pointer(*Uint64T)] words 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_int_of_arbitrary_precision, :LLVMConstIntOfArbitraryPrecision, [:pointer, :uint, :pointer], :pointer
-
-  # (Not documented)
+  attach_function :const_int_of_arbitrary_precision, :LLVMConstIntOfArbitraryPrecision, [OpaqueType, :uint, :pointer], OpaqueValue
+  
+  # Obtain a constant value for an integer parsed from a string.
+  # 
+  # A similar API, LLVMConstIntOfStringAndSize is also available. If the
+  # string's length is available, it is preferred to call that function
+  # instead.
+  # 
+  # @see llvm::ConstantInt::get()
   # 
   # @method const_int_of_string(int_ty, text, radix)
-  # @param [FFI::Pointer(TypeRef)] int_ty 
+  # @param [OpaqueType] int_ty 
   # @param [String] text 
   # @param [Integer] radix 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_int_of_string, :LLVMConstIntOfString, [:pointer, :string, :uchar], :pointer
-
-  # (Not documented)
+  attach_function :const_int_of_string, :LLVMConstIntOfString, [OpaqueType, :string, :uchar], OpaqueValue
+  
+  # Obtain a constant value for an integer parsed from a string with
+  # specified length.
+  # 
+  # @see llvm::ConstantInt::get()
   # 
   # @method const_int_of_string_and_size(int_ty, text, s_len, radix)
-  # @param [FFI::Pointer(TypeRef)] int_ty 
+  # @param [OpaqueType] int_ty 
   # @param [String] text 
   # @param [Integer] s_len 
   # @param [Integer] radix 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_int_of_string_and_size, :LLVMConstIntOfStringAndSize, [:pointer, :string, :uint, :uchar], :pointer
-
-  # (Not documented)
+  attach_function :const_int_of_string_and_size, :LLVMConstIntOfStringAndSize, [OpaqueType, :string, :uint, :uchar], OpaqueValue
+  
+  # Obtain a constant value referring to a double floating point value.
   # 
   # @method const_real(real_ty, n)
-  # @param [FFI::Pointer(TypeRef)] real_ty 
+  # @param [OpaqueType] real_ty 
   # @param [Float] n 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_real, :LLVMConstReal, [:pointer, :double], :pointer
-
-  # (Not documented)
+  attach_function :const_real, :LLVMConstReal, [OpaqueType, :double], OpaqueValue
+  
+  # Obtain a constant for a floating point value parsed from a string.
+  # 
+  # A similar API, LLVMConstRealOfStringAndSize is also available. It
+  # should be used if the input string's length is known.
   # 
   # @method const_real_of_string(real_ty, text)
-  # @param [FFI::Pointer(TypeRef)] real_ty 
+  # @param [OpaqueType] real_ty 
   # @param [String] text 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_real_of_string, :LLVMConstRealOfString, [:pointer, :string], :pointer
-
-  # (Not documented)
+  attach_function :const_real_of_string, :LLVMConstRealOfString, [OpaqueType, :string], OpaqueValue
+  
+  # Obtain a constant for a floating point value parsed from a string.
   # 
   # @method const_real_of_string_and_size(real_ty, text, s_len)
-  # @param [FFI::Pointer(TypeRef)] real_ty 
+  # @param [OpaqueType] real_ty 
   # @param [String] text 
   # @param [Integer] s_len 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_real_of_string_and_size, :LLVMConstRealOfStringAndSize, [:pointer, :string, :uint], :pointer
-
-  # (Not documented)
+  attach_function :const_real_of_string_and_size, :LLVMConstRealOfStringAndSize, [OpaqueType, :string, :uint], OpaqueValue
+  
+  # Obtain the zero extended value for an integer constant value.
+  # 
+  # @see llvm::ConstantInt::getZExtValue()
   # 
   # @method const_int_get_z_ext_value(constant_val)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
+  # @param [OpaqueValue] constant_val 
   # @return [Integer] 
   # @scope class
-  attach_function :const_int_get_z_ext_value, :LLVMConstIntGetZExtValue, [:pointer], :ulong_long
-
-  # (Not documented)
+  attach_function :const_int_get_z_ext_value, :LLVMConstIntGetZExtValue, [OpaqueValue], :ulong_long
+  
+  # Obtain the sign extended value for an integer constant value.
+  # 
+  # @see llvm::ConstantInt::getSExtValue()
   # 
   # @method const_int_get_s_ext_value(constant_val)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
+  # @param [OpaqueValue] constant_val 
   # @return [Integer] 
   # @scope class
-  attach_function :const_int_get_s_ext_value, :LLVMConstIntGetSExtValue, [:pointer], :long_long
-
-  # Operations on composite constants
+  attach_function :const_int_get_s_ext_value, :LLVMConstIntGetSExtValue, [OpaqueValue], :long_long
+  
+  # Create a ConstantDataSequential and initialize it with a string.
+  # 
+  # @see llvm::ConstantDataArray::getString()
   # 
   # @method const_string_in_context(c, str, length, dont_null_terminate)
-  # @param [FFI::Pointer(ContextRef)] c 
+  # @param [OpaqueContext] c 
   # @param [String] str 
   # @param [Integer] length 
   # @param [Integer] dont_null_terminate 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_string_in_context, :LLVMConstStringInContext, [:pointer, :string, :uint, :int], :pointer
-
-  # (Not documented)
+  attach_function :const_string_in_context, :LLVMConstStringInContext, [OpaqueContext, :string, :uint, :int], OpaqueValue
+  
+  # Create a ConstantDataSequential with string content in the global context.
   # 
-  # @method const_struct_in_context(c, constant_vals, count, packed)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @param [FFI::Pointer(*ValueRef)] constant_vals 
-  # @param [Integer] count 
-  # @param [Integer] packed 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :const_struct_in_context, :LLVMConstStructInContext, [:pointer, :pointer, :uint, :int], :pointer
-
-  # (Not documented)
+  # This is the same as LLVMConstStringInContext except it operates on the
+  # global context.
+  # 
+  # @see LLVMConstStringInContext()
+  # @see llvm::ConstantDataArray::getString()
   # 
   # @method const_string(str, length, dont_null_terminate)
   # @param [String] str 
   # @param [Integer] length 
   # @param [Integer] dont_null_terminate 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_string, :LLVMConstString, [:string, :uint, :int], :pointer
-
-  # (Not documented)
+  attach_function :const_string, :LLVMConstString, [:string, :uint, :int], OpaqueValue
+  
+  # Create an anonymous ConstantStruct with the specified values.
   # 
-  # @method const_array(element_ty, constant_vals, length)
-  # @param [FFI::Pointer(TypeRef)] element_ty 
+  # @see llvm::ConstantStruct::getAnon()
+  # 
+  # @method const_struct_in_context(c, constant_vals, count, packed)
+  # @param [OpaqueContext] c 
   # @param [FFI::Pointer(*ValueRef)] constant_vals 
-  # @param [Integer] length 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [Integer] count 
+  # @param [Integer] packed 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_array, :LLVMConstArray, [:pointer, :pointer, :uint], :pointer
-
-  # (Not documented)
+  attach_function :const_struct_in_context, :LLVMConstStructInContext, [OpaqueContext, :pointer, :uint, :int], OpaqueValue
+  
+  # Create a ConstantStruct in the global Context.
+  # 
+  # This is the same as LLVMConstStructInContext except it operates on the
+  # global Context.
+  # 
+  # @see LLVMConstStructInContext()
   # 
   # @method const_struct(constant_vals, count, packed)
   # @param [FFI::Pointer(*ValueRef)] constant_vals 
   # @param [Integer] count 
   # @param [Integer] packed 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_struct, :LLVMConstStruct, [:pointer, :uint, :int], :pointer
-
-  # (Not documented)
+  attach_function :const_struct, :LLVMConstStruct, [:pointer, :uint, :int], OpaqueValue
+  
+  # Create a ConstantArray from values.
+  # 
+  # @see llvm::ConstantArray::get()
+  # 
+  # @method const_array(element_ty, constant_vals, length)
+  # @param [OpaqueType] element_ty 
+  # @param [FFI::Pointer(*ValueRef)] constant_vals 
+  # @param [Integer] length 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :const_array, :LLVMConstArray, [OpaqueType, :pointer, :uint], OpaqueValue
+  
+  # Create a non-anonymous ConstantStruct from values.
+  # 
+  # @see llvm::ConstantStruct::get()
   # 
   # @method const_named_struct(struct_ty, constant_vals, count)
-  # @param [FFI::Pointer(TypeRef)] struct_ty 
+  # @param [OpaqueType] struct_ty 
   # @param [FFI::Pointer(*ValueRef)] constant_vals 
   # @param [Integer] count 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_named_struct, :LLVMConstNamedStruct, [:pointer, :pointer, :uint], :pointer
-
-  # (Not documented)
+  attach_function :const_named_struct, :LLVMConstNamedStruct, [OpaqueType, :pointer, :uint], OpaqueValue
+  
+  # Create a ConstantVector from values.
+  # 
+  # @see llvm::ConstantVector::get()
   # 
   # @method const_vector(scalar_constant_vals, size)
   # @param [FFI::Pointer(*ValueRef)] scalar_constant_vals 
   # @param [Integer] size 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_vector, :LLVMConstVector, [:pointer, :uint], :pointer
-
-  # Constant expressions
+  attach_function :const_vector, :LLVMConstVector, [:pointer, :uint], OpaqueValue
+  
+  # @defgroup LLVMCCoreValueConstantExpressions Constant Expressions
+  # 
+  # Functions in this group correspond to APIs on llvm::ConstantExpr.
+  # 
+  # @see llvm::ConstantExpr.
+  # 
+  # @{
   # 
   # @method get_const_opcode(constant_val)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @return [Symbol from opcode_enum] 
+  # @param [OpaqueValue] constant_val 
+  # @return [Symbol from _enum_opcode_] 
   # @scope class
-  attach_function :get_const_opcode, :LLVMGetConstOpcode, [:pointer], :opcode
-
+  attach_function :get_const_opcode, :LLVMGetConstOpcode, [OpaqueValue], :opcode
+  
   # (Not documented)
   # 
   # @method align_of(ty)
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueType] ty 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :align_of, :LLVMAlignOf, [:pointer], :pointer
-
+  attach_function :align_of, :LLVMAlignOf, [OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method size_of(ty)
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueType] ty 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :size_of, :LLVMSizeOf, [:pointer], :pointer
-
+  attach_function :size_of, :LLVMSizeOf, [OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_neg(constant_val)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_neg, :LLVMConstNeg, [:pointer], :pointer
-
+  attach_function :const_neg, :LLVMConstNeg, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_nsw_neg(constant_val)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_nsw_neg, :LLVMConstNSWNeg, [:pointer], :pointer
-
+  attach_function :const_nsw_neg, :LLVMConstNSWNeg, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_nuw_neg(constant_val)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_nuw_neg, :LLVMConstNUWNeg, [:pointer], :pointer
-
+  attach_function :const_nuw_neg, :LLVMConstNUWNeg, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_f_neg(constant_val)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_f_neg, :LLVMConstFNeg, [:pointer], :pointer
-
+  attach_function :const_f_neg, :LLVMConstFNeg, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_not(constant_val)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_not, :LLVMConstNot, [:pointer], :pointer
-
+  attach_function :const_not, :LLVMConstNot, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_add(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_add, :LLVMConstAdd, [:pointer, :pointer], :pointer
-
+  attach_function :const_add, :LLVMConstAdd, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_nsw_add(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_nsw_add, :LLVMConstNSWAdd, [:pointer, :pointer], :pointer
-
+  attach_function :const_nsw_add, :LLVMConstNSWAdd, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_nuw_add(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_nuw_add, :LLVMConstNUWAdd, [:pointer, :pointer], :pointer
-
+  attach_function :const_nuw_add, :LLVMConstNUWAdd, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_f_add(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_f_add, :LLVMConstFAdd, [:pointer, :pointer], :pointer
-
+  attach_function :const_f_add, :LLVMConstFAdd, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_sub(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_sub, :LLVMConstSub, [:pointer, :pointer], :pointer
-
+  attach_function :const_sub, :LLVMConstSub, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_nsw_sub(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_nsw_sub, :LLVMConstNSWSub, [:pointer, :pointer], :pointer
-
+  attach_function :const_nsw_sub, :LLVMConstNSWSub, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_nuw_sub(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_nuw_sub, :LLVMConstNUWSub, [:pointer, :pointer], :pointer
-
+  attach_function :const_nuw_sub, :LLVMConstNUWSub, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_f_sub(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_f_sub, :LLVMConstFSub, [:pointer, :pointer], :pointer
-
+  attach_function :const_f_sub, :LLVMConstFSub, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_mul(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_mul, :LLVMConstMul, [:pointer, :pointer], :pointer
-
+  attach_function :const_mul, :LLVMConstMul, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_nsw_mul(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_nsw_mul, :LLVMConstNSWMul, [:pointer, :pointer], :pointer
-
+  attach_function :const_nsw_mul, :LLVMConstNSWMul, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_nuw_mul(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_nuw_mul, :LLVMConstNUWMul, [:pointer, :pointer], :pointer
-
+  attach_function :const_nuw_mul, :LLVMConstNUWMul, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_f_mul(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_f_mul, :LLVMConstFMul, [:pointer, :pointer], :pointer
-
+  attach_function :const_f_mul, :LLVMConstFMul, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_u_div(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_u_div, :LLVMConstUDiv, [:pointer, :pointer], :pointer
-
+  attach_function :const_u_div, :LLVMConstUDiv, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_s_div(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_s_div, :LLVMConstSDiv, [:pointer, :pointer], :pointer
-
+  attach_function :const_s_div, :LLVMConstSDiv, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_exact_s_div(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_exact_s_div, :LLVMConstExactSDiv, [:pointer, :pointer], :pointer
-
+  attach_function :const_exact_s_div, :LLVMConstExactSDiv, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_f_div(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_f_div, :LLVMConstFDiv, [:pointer, :pointer], :pointer
-
+  attach_function :const_f_div, :LLVMConstFDiv, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_u_rem(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_u_rem, :LLVMConstURem, [:pointer, :pointer], :pointer
-
+  attach_function :const_u_rem, :LLVMConstURem, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_s_rem(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_s_rem, :LLVMConstSRem, [:pointer, :pointer], :pointer
-
+  attach_function :const_s_rem, :LLVMConstSRem, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_f_rem(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_f_rem, :LLVMConstFRem, [:pointer, :pointer], :pointer
-
+  attach_function :const_f_rem, :LLVMConstFRem, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_and(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_and, :LLVMConstAnd, [:pointer, :pointer], :pointer
-
+  attach_function :const_and, :LLVMConstAnd, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_or(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_or, :LLVMConstOr, [:pointer, :pointer], :pointer
-
+  attach_function :const_or, :LLVMConstOr, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_xor(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_xor, :LLVMConstXor, [:pointer, :pointer], :pointer
-
+  attach_function :const_xor, :LLVMConstXor, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_i_cmp(predicate, lhs_constant, rhs_constant)
-  # @param [Symbol from int_predicate_enum] predicate 
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [Symbol from _enum_int_predicate_] predicate 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_i_cmp, :LLVMConstICmp, [:int_predicate, :pointer, :pointer], :pointer
-
+  attach_function :const_i_cmp, :LLVMConstICmp, [:int_predicate, OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_f_cmp(predicate, lhs_constant, rhs_constant)
-  # @param [Symbol from real_predicate_enum] predicate 
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [Symbol from _enum_real_predicate_] predicate 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_f_cmp, :LLVMConstFCmp, [:real_predicate, :pointer, :pointer], :pointer
-
+  attach_function :const_f_cmp, :LLVMConstFCmp, [:real_predicate, OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_shl(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_shl, :LLVMConstShl, [:pointer, :pointer], :pointer
-
+  attach_function :const_shl, :LLVMConstShl, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_l_shr(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_l_shr, :LLVMConstLShr, [:pointer, :pointer], :pointer
-
+  attach_function :const_l_shr, :LLVMConstLShr, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_a_shr(lhs_constant, rhs_constant)
-  # @param [FFI::Pointer(ValueRef)] lhs_constant 
-  # @param [FFI::Pointer(ValueRef)] rhs_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] lhs_constant 
+  # @param [OpaqueValue] rhs_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_a_shr, :LLVMConstAShr, [:pointer, :pointer], :pointer
-
+  attach_function :const_a_shr, :LLVMConstAShr, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_gep(constant_val, constant_indices, num_indices)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
+  # @param [OpaqueValue] constant_val 
   # @param [FFI::Pointer(*ValueRef)] constant_indices 
   # @param [Integer] num_indices 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_gep, :LLVMConstGEP, [:pointer, :pointer, :uint], :pointer
-
+  attach_function :const_gep, :LLVMConstGEP, [OpaqueValue, :pointer, :uint], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_in_bounds_gep(constant_val, constant_indices, num_indices)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
+  # @param [OpaqueValue] constant_val 
   # @param [FFI::Pointer(*ValueRef)] constant_indices 
   # @param [Integer] num_indices 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_in_bounds_gep, :LLVMConstInBoundsGEP, [:pointer, :pointer, :uint], :pointer
-
+  attach_function :const_in_bounds_gep, :LLVMConstInBoundsGEP, [OpaqueValue, :pointer, :uint], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_trunc(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_trunc, :LLVMConstTrunc, [:pointer, :pointer], :pointer
-
+  attach_function :const_trunc, :LLVMConstTrunc, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_s_ext(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_s_ext, :LLVMConstSExt, [:pointer, :pointer], :pointer
-
+  attach_function :const_s_ext, :LLVMConstSExt, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_z_ext(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_z_ext, :LLVMConstZExt, [:pointer, :pointer], :pointer
-
+  attach_function :const_z_ext, :LLVMConstZExt, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_fp_trunc(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_fp_trunc, :LLVMConstFPTrunc, [:pointer, :pointer], :pointer
-
+  attach_function :const_fp_trunc, :LLVMConstFPTrunc, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_fp_ext(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_fp_ext, :LLVMConstFPExt, [:pointer, :pointer], :pointer
-
+  attach_function :const_fp_ext, :LLVMConstFPExt, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_ui_to_fp(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_ui_to_fp, :LLVMConstUIToFP, [:pointer, :pointer], :pointer
-
+  attach_function :const_ui_to_fp, :LLVMConstUIToFP, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_si_to_fp(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_si_to_fp, :LLVMConstSIToFP, [:pointer, :pointer], :pointer
-
+  attach_function :const_si_to_fp, :LLVMConstSIToFP, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_fp_to_ui(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_fp_to_ui, :LLVMConstFPToUI, [:pointer, :pointer], :pointer
-
+  attach_function :const_fp_to_ui, :LLVMConstFPToUI, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_fp_to_si(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_fp_to_si, :LLVMConstFPToSI, [:pointer, :pointer], :pointer
-
+  attach_function :const_fp_to_si, :LLVMConstFPToSI, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_ptr_to_int(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_ptr_to_int, :LLVMConstPtrToInt, [:pointer, :pointer], :pointer
-
+  attach_function :const_ptr_to_int, :LLVMConstPtrToInt, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_int_to_ptr(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_int_to_ptr, :LLVMConstIntToPtr, [:pointer, :pointer], :pointer
-
+  attach_function :const_int_to_ptr, :LLVMConstIntToPtr, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_bit_cast(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_bit_cast, :LLVMConstBitCast, [:pointer, :pointer], :pointer
-
+  attach_function :const_bit_cast, :LLVMConstBitCast, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_z_ext_or_bit_cast(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_z_ext_or_bit_cast, :LLVMConstZExtOrBitCast, [:pointer, :pointer], :pointer
-
+  attach_function :const_z_ext_or_bit_cast, :LLVMConstZExtOrBitCast, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_s_ext_or_bit_cast(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_s_ext_or_bit_cast, :LLVMConstSExtOrBitCast, [:pointer, :pointer], :pointer
-
+  attach_function :const_s_ext_or_bit_cast, :LLVMConstSExtOrBitCast, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_trunc_or_bit_cast(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_trunc_or_bit_cast, :LLVMConstTruncOrBitCast, [:pointer, :pointer], :pointer
-
+  attach_function :const_trunc_or_bit_cast, :LLVMConstTruncOrBitCast, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_pointer_cast(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_pointer_cast, :LLVMConstPointerCast, [:pointer, :pointer], :pointer
-
+  attach_function :const_pointer_cast, :LLVMConstPointerCast, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_int_cast(constant_val, to_type, is_signed)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
   # @param [Integer] is_signed 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_int_cast, :LLVMConstIntCast, [:pointer, :pointer, :int], :pointer
-
+  attach_function :const_int_cast, :LLVMConstIntCast, [OpaqueValue, OpaqueType, :int], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_fp_cast(constant_val, to_type)
-  # @param [FFI::Pointer(ValueRef)] constant_val 
-  # @param [FFI::Pointer(TypeRef)] to_type 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_val 
+  # @param [OpaqueType] to_type 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_fp_cast, :LLVMConstFPCast, [:pointer, :pointer], :pointer
-
+  attach_function :const_fp_cast, :LLVMConstFPCast, [OpaqueValue, OpaqueType], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_select(constant_condition, constant_if_true, constant_if_false)
-  # @param [FFI::Pointer(ValueRef)] constant_condition 
-  # @param [FFI::Pointer(ValueRef)] constant_if_true 
-  # @param [FFI::Pointer(ValueRef)] constant_if_false 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] constant_condition 
+  # @param [OpaqueValue] constant_if_true 
+  # @param [OpaqueValue] constant_if_false 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_select, :LLVMConstSelect, [:pointer, :pointer, :pointer], :pointer
-
+  attach_function :const_select, :LLVMConstSelect, [OpaqueValue, OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_extract_element(vector_constant, index_constant)
-  # @param [FFI::Pointer(ValueRef)] vector_constant 
-  # @param [FFI::Pointer(ValueRef)] index_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] vector_constant 
+  # @param [OpaqueValue] index_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_extract_element, :LLVMConstExtractElement, [:pointer, :pointer], :pointer
-
+  attach_function :const_extract_element, :LLVMConstExtractElement, [OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_insert_element(vector_constant, element_value_constant, index_constant)
-  # @param [FFI::Pointer(ValueRef)] vector_constant 
-  # @param [FFI::Pointer(ValueRef)] element_value_constant 
-  # @param [FFI::Pointer(ValueRef)] index_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] vector_constant 
+  # @param [OpaqueValue] element_value_constant 
+  # @param [OpaqueValue] index_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_insert_element, :LLVMConstInsertElement, [:pointer, :pointer, :pointer], :pointer
-
+  attach_function :const_insert_element, :LLVMConstInsertElement, [OpaqueValue, OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_shuffle_vector(vector_a_constant, vector_b_constant, mask_constant)
-  # @param [FFI::Pointer(ValueRef)] vector_a_constant 
-  # @param [FFI::Pointer(ValueRef)] vector_b_constant 
-  # @param [FFI::Pointer(ValueRef)] mask_constant 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] vector_a_constant 
+  # @param [OpaqueValue] vector_b_constant 
+  # @param [OpaqueValue] mask_constant 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_shuffle_vector, :LLVMConstShuffleVector, [:pointer, :pointer, :pointer], :pointer
-
+  attach_function :const_shuffle_vector, :LLVMConstShuffleVector, [OpaqueValue, OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_extract_value(agg_constant, idx_list, num_idx)
-  # @param [FFI::Pointer(ValueRef)] agg_constant 
+  # @param [OpaqueValue] agg_constant 
   # @param [FFI::Pointer(*UInt)] idx_list 
   # @param [Integer] num_idx 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_extract_value, :LLVMConstExtractValue, [:pointer, :pointer, :uint], :pointer
-
+  attach_function :const_extract_value, :LLVMConstExtractValue, [OpaqueValue, :pointer, :uint], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_insert_value(agg_constant, element_value_constant, idx_list, num_idx)
-  # @param [FFI::Pointer(ValueRef)] agg_constant 
-  # @param [FFI::Pointer(ValueRef)] element_value_constant 
+  # @param [OpaqueValue] agg_constant 
+  # @param [OpaqueValue] element_value_constant 
   # @param [FFI::Pointer(*UInt)] idx_list 
   # @param [Integer] num_idx 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_insert_value, :LLVMConstInsertValue, [:pointer, :pointer, :pointer, :uint], :pointer
-
+  attach_function :const_insert_value, :LLVMConstInsertValue, [OpaqueValue, OpaqueValue, :pointer, :uint], OpaqueValue
+  
   # (Not documented)
   # 
   # @method const_inline_asm(ty, asm_string, constraints, has_side_effects, is_align_stack)
-  # @param [FFI::Pointer(TypeRef)] ty 
+  # @param [OpaqueType] ty 
   # @param [String] asm_string 
   # @param [String] constraints 
   # @param [Integer] has_side_effects 
   # @param [Integer] is_align_stack 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :const_inline_asm, :LLVMConstInlineAsm, [:pointer, :string, :string, :int, :int], :pointer
-
+  attach_function :const_inline_asm, :LLVMConstInlineAsm, [OpaqueType, :string, :string, :int, :int], OpaqueValue
+  
   # (Not documented)
   # 
   # @method block_address(f, bb)
-  # @param [FFI::Pointer(ValueRef)] f 
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] f 
+  # @param [OpaqueBasicBlock] bb 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :block_address, :LLVMBlockAddress, [:pointer, :pointer], :pointer
-
-  # Operations on global variables, functions, and aliases (globals)
+  attach_function :block_address, :LLVMBlockAddress, [OpaqueValue, OpaqueBasicBlock], OpaqueValue
+  
+  # @defgroup LLVMCCoreValueConstantGlobals Global Values
+  # 
+  # This group contains functions that operate on global values. Functions in
+  # this group relate to functions in the llvm::GlobalValue class tree.
+  # 
+  # @see llvm::GlobalValue
+  # 
+  # @{
   # 
   # @method get_global_parent(global)
-  # @param [FFI::Pointer(ValueRef)] global 
-  # @return [FFI::Pointer(ModuleRef)] 
+  # @param [OpaqueValue] global 
+  # @return [OpaqueModule] 
   # @scope class
-  attach_function :get_global_parent, :LLVMGetGlobalParent, [:pointer], :pointer
-
+  attach_function :get_global_parent, :LLVMGetGlobalParent, [OpaqueValue], OpaqueModule
+  
   # (Not documented)
   # 
   # @method is_declaration(global)
-  # @param [FFI::Pointer(ValueRef)] global 
+  # @param [OpaqueValue] global 
   # @return [Integer] 
   # @scope class
-  attach_function :is_declaration, :LLVMIsDeclaration, [:pointer], :int
-
+  attach_function :is_declaration, :LLVMIsDeclaration, [OpaqueValue], :int
+  
   # (Not documented)
   # 
   # @method get_linkage(global)
-  # @param [FFI::Pointer(ValueRef)] global 
-  # @return [Symbol from linkage_enum] 
+  # @param [OpaqueValue] global 
+  # @return [Symbol from _enum_linkage_] 
   # @scope class
-  attach_function :get_linkage, :LLVMGetLinkage, [:pointer], :linkage
-
+  attach_function :get_linkage, :LLVMGetLinkage, [OpaqueValue], :linkage
+  
   # (Not documented)
   # 
   # @method set_linkage(global, linkage)
-  # @param [FFI::Pointer(ValueRef)] global 
-  # @param [Symbol from linkage_enum] linkage 
+  # @param [OpaqueValue] global 
+  # @param [Symbol from _enum_linkage_] linkage 
   # @return [nil] 
   # @scope class
-  attach_function :set_linkage, :LLVMSetLinkage, [:pointer, :linkage], :void
-
+  attach_function :set_linkage, :LLVMSetLinkage, [OpaqueValue, :linkage], :void
+  
   # (Not documented)
   # 
   # @method get_section(global)
-  # @param [FFI::Pointer(ValueRef)] global 
+  # @param [OpaqueValue] global 
   # @return [String] 
   # @scope class
-  attach_function :get_section, :LLVMGetSection, [:pointer], :string
-
+  attach_function :get_section, :LLVMGetSection, [OpaqueValue], :string
+  
   # (Not documented)
   # 
   # @method set_section(global, section)
-  # @param [FFI::Pointer(ValueRef)] global 
+  # @param [OpaqueValue] global 
   # @param [String] section 
   # @return [nil] 
   # @scope class
-  attach_function :set_section, :LLVMSetSection, [:pointer, :string], :void
-
+  attach_function :set_section, :LLVMSetSection, [OpaqueValue, :string], :void
+  
   # (Not documented)
   # 
   # @method get_visibility(global)
-  # @param [FFI::Pointer(ValueRef)] global 
-  # @return [Symbol from visibility_enum] 
+  # @param [OpaqueValue] global 
+  # @return [Symbol from _enum_visibility_] 
   # @scope class
-  attach_function :get_visibility, :LLVMGetVisibility, [:pointer], :visibility
-
+  attach_function :get_visibility, :LLVMGetVisibility, [OpaqueValue], :visibility
+  
   # (Not documented)
   # 
   # @method set_visibility(global, viz)
-  # @param [FFI::Pointer(ValueRef)] global 
-  # @param [Symbol from visibility_enum] viz 
+  # @param [OpaqueValue] global 
+  # @param [Symbol from _enum_visibility_] viz 
   # @return [nil] 
   # @scope class
-  attach_function :set_visibility, :LLVMSetVisibility, [:pointer, :visibility], :void
-
+  attach_function :set_visibility, :LLVMSetVisibility, [OpaqueValue, :visibility], :void
+  
   # (Not documented)
   # 
   # @method get_alignment(global)
-  # @param [FFI::Pointer(ValueRef)] global 
+  # @param [OpaqueValue] global 
   # @return [Integer] 
   # @scope class
-  attach_function :get_alignment, :LLVMGetAlignment, [:pointer], :uint
-
+  attach_function :get_alignment, :LLVMGetAlignment, [OpaqueValue], :uint
+  
   # (Not documented)
   # 
   # @method set_alignment(global, bytes)
-  # @param [FFI::Pointer(ValueRef)] global 
+  # @param [OpaqueValue] global 
   # @param [Integer] bytes 
   # @return [nil] 
   # @scope class
-  attach_function :set_alignment, :LLVMSetAlignment, [:pointer, :uint], :void
-
-  # Operations on global variables
+  attach_function :set_alignment, :LLVMSetAlignment, [OpaqueValue, :uint], :void
+  
+  # @defgroup LLVMCoreValueConstantGlobalVariable Global Variables
+  # 
+  # This group contains functions that operate on global variable values.
+  # 
+  # @see llvm::GlobalVariable
+  # 
+  # @{
   # 
   # @method add_global(m, ty, name)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @param [FFI::Pointer(TypeRef)] ty 
+  # @param [OpaqueModule] m 
+  # @param [OpaqueType] ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :add_global, :LLVMAddGlobal, [:pointer, :pointer, :string], :pointer
-
+  attach_function :add_global, :LLVMAddGlobal, [OpaqueModule, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method add_global_in_address_space(m, ty, name, address_space)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @param [FFI::Pointer(TypeRef)] ty 
+  # @param [OpaqueModule] m 
+  # @param [OpaqueType] ty 
   # @param [String] name 
   # @param [Integer] address_space 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :add_global_in_address_space, :LLVMAddGlobalInAddressSpace, [:pointer, :pointer, :string, :uint], :pointer
-
+  attach_function :add_global_in_address_space, :LLVMAddGlobalInAddressSpace, [OpaqueModule, OpaqueType, :string, :uint], OpaqueValue
+  
   # (Not documented)
   # 
   # @method get_named_global(m, name)
-  # @param [FFI::Pointer(ModuleRef)] m 
+  # @param [OpaqueModule] m 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_named_global, :LLVMGetNamedGlobal, [:pointer, :string], :pointer
-
+  attach_function :get_named_global, :LLVMGetNamedGlobal, [OpaqueModule, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method get_first_global(m)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueModule] m 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_first_global, :LLVMGetFirstGlobal, [:pointer], :pointer
-
+  attach_function :get_first_global, :LLVMGetFirstGlobal, [OpaqueModule], OpaqueValue
+  
   # (Not documented)
   # 
   # @method get_last_global(m)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueModule] m 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_last_global, :LLVMGetLastGlobal, [:pointer], :pointer
-
+  attach_function :get_last_global, :LLVMGetLastGlobal, [OpaqueModule], OpaqueValue
+  
   # (Not documented)
   # 
   # @method get_next_global(global_var)
-  # @param [FFI::Pointer(ValueRef)] global_var 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] global_var 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_next_global, :LLVMGetNextGlobal, [:pointer], :pointer
-
+  attach_function :get_next_global, :LLVMGetNextGlobal, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method get_previous_global(global_var)
-  # @param [FFI::Pointer(ValueRef)] global_var 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] global_var 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_previous_global, :LLVMGetPreviousGlobal, [:pointer], :pointer
-
+  attach_function :get_previous_global, :LLVMGetPreviousGlobal, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method delete_global(global_var)
-  # @param [FFI::Pointer(ValueRef)] global_var 
+  # @param [OpaqueValue] global_var 
   # @return [nil] 
   # @scope class
-  attach_function :delete_global, :LLVMDeleteGlobal, [:pointer], :void
-
+  attach_function :delete_global, :LLVMDeleteGlobal, [OpaqueValue], :void
+  
   # (Not documented)
   # 
   # @method get_initializer(global_var)
-  # @param [FFI::Pointer(ValueRef)] global_var 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] global_var 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_initializer, :LLVMGetInitializer, [:pointer], :pointer
-
+  attach_function :get_initializer, :LLVMGetInitializer, [OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method set_initializer(global_var, constant_val)
-  # @param [FFI::Pointer(ValueRef)] global_var 
-  # @param [FFI::Pointer(ValueRef)] constant_val 
+  # @param [OpaqueValue] global_var 
+  # @param [OpaqueValue] constant_val 
   # @return [nil] 
   # @scope class
-  attach_function :set_initializer, :LLVMSetInitializer, [:pointer, :pointer], :void
-
+  attach_function :set_initializer, :LLVMSetInitializer, [OpaqueValue, OpaqueValue], :void
+  
   # (Not documented)
   # 
   # @method is_thread_local(global_var)
-  # @param [FFI::Pointer(ValueRef)] global_var 
+  # @param [OpaqueValue] global_var 
   # @return [Integer] 
   # @scope class
-  attach_function :is_thread_local, :LLVMIsThreadLocal, [:pointer], :int
-
+  attach_function :is_thread_local, :LLVMIsThreadLocal, [OpaqueValue], :int
+  
   # (Not documented)
   # 
   # @method set_thread_local(global_var, is_thread_local)
-  # @param [FFI::Pointer(ValueRef)] global_var 
+  # @param [OpaqueValue] global_var 
   # @param [Integer] is_thread_local 
   # @return [nil] 
   # @scope class
-  attach_function :set_thread_local, :LLVMSetThreadLocal, [:pointer, :int], :void
-
+  attach_function :set_thread_local, :LLVMSetThreadLocal, [OpaqueValue, :int], :void
+  
   # (Not documented)
   # 
   # @method is_global_constant(global_var)
-  # @param [FFI::Pointer(ValueRef)] global_var 
+  # @param [OpaqueValue] global_var 
   # @return [Integer] 
   # @scope class
-  attach_function :is_global_constant, :LLVMIsGlobalConstant, [:pointer], :int
-
+  attach_function :is_global_constant, :LLVMIsGlobalConstant, [OpaqueValue], :int
+  
   # (Not documented)
   # 
   # @method set_global_constant(global_var, is_constant)
-  # @param [FFI::Pointer(ValueRef)] global_var 
+  # @param [OpaqueValue] global_var 
   # @param [Integer] is_constant 
   # @return [nil] 
   # @scope class
-  attach_function :set_global_constant, :LLVMSetGlobalConstant, [:pointer, :int], :void
-
-  # Operations on aliases
+  attach_function :set_global_constant, :LLVMSetGlobalConstant, [OpaqueValue, :int], :void
+  
+  # @defgroup LLVMCoreValueConstantGlobalAlias Global Aliases
+  # 
+  # This group contains function that operate on global alias values.
+  # 
+  # @see llvm::GlobalAlias
+  # 
+  # @{
   # 
   # @method add_alias(m, ty, aliasee, name)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @param [FFI::Pointer(ValueRef)] aliasee 
+  # @param [OpaqueModule] m 
+  # @param [OpaqueType] ty 
+  # @param [OpaqueValue] aliasee 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :add_alias, :LLVMAddAlias, [:pointer, :pointer, :pointer, :string], :pointer
-
-  # Operations on functions
+  attach_function :add_alias, :LLVMAddAlias, [OpaqueModule, OpaqueType, OpaqueValue, :string], OpaqueValue
+  
+  # Remove a function from its containing module and deletes it.
   # 
-  # @method add_function(m, name, function_ty)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @param [String] name 
-  # @param [FFI::Pointer(TypeRef)] function_ty 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :add_function, :LLVMAddFunction, [:pointer, :string, :pointer], :pointer
-
-  # (Not documented)
-  # 
-  # @method get_named_function(m, name)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :get_named_function, :LLVMGetNamedFunction, [:pointer, :string], :pointer
-
-  # (Not documented)
-  # 
-  # @method get_first_function(m)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :get_first_function, :LLVMGetFirstFunction, [:pointer], :pointer
-
-  # (Not documented)
-  # 
-  # @method get_last_function(m)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :get_last_function, :LLVMGetLastFunction, [:pointer], :pointer
-
-  # (Not documented)
-  # 
-  # @method get_next_function(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :get_next_function, :LLVMGetNextFunction, [:pointer], :pointer
-
-  # (Not documented)
-  # 
-  # @method get_previous_function(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :get_previous_function, :LLVMGetPreviousFunction, [:pointer], :pointer
-
-  # (Not documented)
+  # @see llvm::Function::eraseFromParent()
   # 
   # @method delete_function(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @return [nil] 
   # @scope class
-  attach_function :delete_function, :LLVMDeleteFunction, [:pointer], :void
-
-  # (Not documented)
+  attach_function :delete_function, :LLVMDeleteFunction, [OpaqueValue], :void
+  
+  # Obtain the ID number from a function instance.
+  # 
+  # @see llvm::Function::getIntrinsicID()
   # 
   # @method get_intrinsic_id(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @return [Integer] 
   # @scope class
-  attach_function :get_intrinsic_id, :LLVMGetIntrinsicID, [:pointer], :uint
-
-  # (Not documented)
+  attach_function :get_intrinsic_id, :LLVMGetIntrinsicID, [OpaqueValue], :uint
+  
+  # Obtain the calling function of a function.
+  # 
+  # The returned value corresponds to the LLVMCallConv enumeration.
+  # 
+  # @see llvm::Function::getCallingConv()
   # 
   # @method get_function_call_conv(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @return [Integer] 
   # @scope class
-  attach_function :get_function_call_conv, :LLVMGetFunctionCallConv, [:pointer], :uint
-
-  # (Not documented)
+  attach_function :get_function_call_conv, :LLVMGetFunctionCallConv, [OpaqueValue], :uint
+  
+  # Set the calling convention of a function.
+  # 
+  # @see llvm::Function::setCallingConv()
+  # 
+  # @param Fn Function to operate on
+  # @param CC LLVMCallConv to set calling convention to
   # 
   # @method set_function_call_conv(fn, cc)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @param [Integer] cc 
   # @return [nil] 
   # @scope class
-  attach_function :set_function_call_conv, :LLVMSetFunctionCallConv, [:pointer, :uint], :void
-
-  # (Not documented)
+  attach_function :set_function_call_conv, :LLVMSetFunctionCallConv, [OpaqueValue, :uint], :void
+  
+  # Obtain the name of the garbage collector to use during code
+  # generation.
+  # 
+  # @see llvm::Function::getGC()
   # 
   # @method get_gc(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @return [String] 
   # @scope class
-  attach_function :get_gc, :LLVMGetGC, [:pointer], :string
-
-  # (Not documented)
+  attach_function :get_gc, :LLVMGetGC, [OpaqueValue], :string
+  
+  # Define the garbage collector to use during code generation.
+  # 
+  # @see llvm::Function::setGC()
   # 
   # @method set_gc(fn, name)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @param [String] name 
   # @return [nil] 
   # @scope class
-  attach_function :set_gc, :LLVMSetGC, [:pointer, :string], :void
-
-  # (Not documented)
+  attach_function :set_gc, :LLVMSetGC, [OpaqueValue, :string], :void
+  
+  # Add an attribute to a function.
+  # 
+  # @see llvm::Function::addAttribute()
   # 
   # @method add_function_attr(fn, pa)
-  # @param [FFI::Pointer(ValueRef)] fn 
-  # @param [Symbol from attribute_enum] pa 
+  # @param [OpaqueValue] fn 
+  # @param [Symbol from _enum_attribute_] pa 
   # @return [nil] 
   # @scope class
-  attach_function :add_function_attr, :LLVMAddFunctionAttr, [:pointer, :attribute], :void
-
-  # (Not documented)
+  attach_function :add_function_attr, :LLVMAddFunctionAttr, [OpaqueValue, :attribute], :void
+  
+  # Obtain an attribute from a function.
+  # 
+  # @see llvm::Function::getAttributes()
   # 
   # @method get_function_attr(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
-  # @return [Symbol from attribute_enum] 
+  # @param [OpaqueValue] fn 
+  # @return [Symbol from _enum_attribute_] 
   # @scope class
-  attach_function :get_function_attr, :LLVMGetFunctionAttr, [:pointer], :attribute
-
-  # (Not documented)
+  attach_function :get_function_attr, :LLVMGetFunctionAttr, [OpaqueValue], :attribute
+  
+  # Remove an attribute from a function.
   # 
   # @method remove_function_attr(fn, pa)
-  # @param [FFI::Pointer(ValueRef)] fn 
-  # @param [Symbol from attribute_enum] pa 
+  # @param [OpaqueValue] fn 
+  # @param [Symbol from _enum_attribute_] pa 
   # @return [nil] 
   # @scope class
-  attach_function :remove_function_attr, :LLVMRemoveFunctionAttr, [:pointer, :attribute], :void
-
-  # Operations on parameters
+  attach_function :remove_function_attr, :LLVMRemoveFunctionAttr, [OpaqueValue, :attribute], :void
+  
+  # Obtain the number of parameters in a function.
+  # 
+  # @see llvm::Function::arg_size()
   # 
   # @method count_params(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @return [Integer] 
   # @scope class
-  attach_function :count_params, :LLVMCountParams, [:pointer], :uint
-
-  # (Not documented)
+  attach_function :count_params, :LLVMCountParams, [OpaqueValue], :uint
+  
+  # Obtain the parameters in a function.
+  # 
+  # The takes a pointer to a pre-allocated array of LLVMValueRef that is
+  # at least LLVMCountParams() long. This array will be filled with
+  # LLVMValueRef instances which correspond to the parameters the
+  # function receives. Each LLVMValueRef corresponds to a llvm::Argument
+  # instance.
+  # 
+  # @see llvm::Function::arg_begin()
   # 
   # @method get_params(fn, params)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @param [FFI::Pointer(*ValueRef)] params 
   # @return [nil] 
   # @scope class
-  attach_function :get_params, :LLVMGetParams, [:pointer, :pointer], :void
-
-  # (Not documented)
+  attach_function :get_params, :LLVMGetParams, [OpaqueValue, :pointer], :void
+  
+  # Obtain the parameter at the specified index.
+  # 
+  # Parameters are indexed from 0.
+  # 
+  # @see llvm::Function::arg_begin()
   # 
   # @method get_param(fn, index)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @param [Integer] index 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_param, :LLVMGetParam, [:pointer, :uint], :pointer
-
-  # (Not documented)
+  attach_function :get_param, :LLVMGetParam, [OpaqueValue, :uint], OpaqueValue
+  
+  # Obtain the function to which this argument belongs.
+  # 
+  # Unlike other functions in this group, this one takes a LLVMValueRef
+  # that corresponds to a llvm::Attribute.
+  # 
+  # The returned LLVMValueRef is the llvm::Function to which this
+  # argument belongs.
   # 
   # @method get_param_parent(inst)
-  # @param [FFI::Pointer(ValueRef)] inst 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] inst 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_param_parent, :LLVMGetParamParent, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_param_parent, :LLVMGetParamParent, [OpaqueValue], OpaqueValue
+  
+  # Obtain the first parameter to a function.
+  # 
+  # @see llvm::Function::arg_begin()
   # 
   # @method get_first_param(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] fn 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_first_param, :LLVMGetFirstParam, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_first_param, :LLVMGetFirstParam, [OpaqueValue], OpaqueValue
+  
+  # Obtain the last parameter to a function.
+  # 
+  # @see llvm::Function::arg_end()
   # 
   # @method get_last_param(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] fn 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_last_param, :LLVMGetLastParam, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_last_param, :LLVMGetLastParam, [OpaqueValue], OpaqueValue
+  
+  # Obtain the next parameter to a function.
+  # 
+  # This takes a LLVMValueRef obtained from LLVMGetFirstParam() (which is
+  # actually a wrapped iterator) and obtains the next parameter from the
+  # underlying iterator.
   # 
   # @method get_next_param(arg)
-  # @param [FFI::Pointer(ValueRef)] arg 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] arg 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_next_param, :LLVMGetNextParam, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_next_param, :LLVMGetNextParam, [OpaqueValue], OpaqueValue
+  
+  # Obtain the previous parameter to a function.
+  # 
+  # This is the opposite of LLVMGetNextParam().
   # 
   # @method get_previous_param(arg)
-  # @param [FFI::Pointer(ValueRef)] arg 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueValue] arg 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_previous_param, :LLVMGetPreviousParam, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_previous_param, :LLVMGetPreviousParam, [OpaqueValue], OpaqueValue
+  
+  # Add an attribute to a function argument.
+  # 
+  # @see llvm::Argument::addAttr()
   # 
   # @method add_attribute(arg, pa)
-  # @param [FFI::Pointer(ValueRef)] arg 
-  # @param [Symbol from attribute_enum] pa 
+  # @param [OpaqueValue] arg 
+  # @param [Symbol from _enum_attribute_] pa 
   # @return [nil] 
   # @scope class
-  attach_function :add_attribute, :LLVMAddAttribute, [:pointer, :attribute], :void
-
-  # (Not documented)
+  attach_function :add_attribute, :LLVMAddAttribute, [OpaqueValue, :attribute], :void
+  
+  # Remove an attribute from a function argument.
+  # 
+  # @see llvm::Argument::removeAttr()
   # 
   # @method remove_attribute(arg, pa)
-  # @param [FFI::Pointer(ValueRef)] arg 
-  # @param [Symbol from attribute_enum] pa 
+  # @param [OpaqueValue] arg 
+  # @param [Symbol from _enum_attribute_] pa 
   # @return [nil] 
   # @scope class
-  attach_function :remove_attribute, :LLVMRemoveAttribute, [:pointer, :attribute], :void
-
-  # (Not documented)
+  attach_function :remove_attribute, :LLVMRemoveAttribute, [OpaqueValue, :attribute], :void
+  
+  # Get an attribute from a function argument.
   # 
   # @method get_attribute(arg)
-  # @param [FFI::Pointer(ValueRef)] arg 
-  # @return [Symbol from attribute_enum] 
+  # @param [OpaqueValue] arg 
+  # @return [Symbol from _enum_attribute_] 
   # @scope class
-  attach_function :get_attribute, :LLVMGetAttribute, [:pointer], :attribute
-
-  # (Not documented)
+  attach_function :get_attribute, :LLVMGetAttribute, [OpaqueValue], :attribute
+  
+  # Set the alignment for a function parameter.
+  # 
+  # @see llvm::Argument::addAttr()
+  # @see llvm::Attribute::constructAlignmentFromInt()
   # 
   # @method set_param_alignment(arg, align)
-  # @param [FFI::Pointer(ValueRef)] arg 
+  # @param [OpaqueValue] arg 
   # @param [Integer] align 
   # @return [nil] 
   # @scope class
-  attach_function :set_param_alignment, :LLVMSetParamAlignment, [:pointer, :uint], :void
-
-  # Operations on basic blocks
+  attach_function :set_param_alignment, :LLVMSetParamAlignment, [OpaqueValue, :uint], :void
+  
+  # Obtain a MDString value from a context.
+  # 
+  # The returned instance corresponds to the llvm::MDString class.
+  # 
+  # The instance is specified by string data of a specified length. The
+  # string content is copied, so the backing memory can be freed after
+  # this function returns.
+  # 
+  # @method md_string_in_context(c, str, s_len)
+  # @param [OpaqueContext] c 
+  # @param [String] str 
+  # @param [Integer] s_len 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :md_string_in_context, :LLVMMDStringInContext, [OpaqueContext, :string, :uint], OpaqueValue
+  
+  # Obtain a MDString value from the global context.
+  # 
+  # @method md_string(str, s_len)
+  # @param [String] str 
+  # @param [Integer] s_len 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :md_string, :LLVMMDString, [:string, :uint], OpaqueValue
+  
+  # Obtain a MDNode value from a context.
+  # 
+  # The returned value corresponds to the llvm::MDNode class.
+  # 
+  # @method md_node_in_context(c, vals, count)
+  # @param [OpaqueContext] c 
+  # @param [FFI::Pointer(*ValueRef)] vals 
+  # @param [Integer] count 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :md_node_in_context, :LLVMMDNodeInContext, [OpaqueContext, :pointer, :uint], OpaqueValue
+  
+  # Obtain a MDNode value from the global context.
+  # 
+  # @method md_node(vals, count)
+  # @param [FFI::Pointer(*ValueRef)] vals 
+  # @param [Integer] count 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :md_node, :LLVMMDNode, [:pointer, :uint], OpaqueValue
+  
+  # Obtain the underlying string from a MDString value.
+  # 
+  # @param V Instance to obtain string from.
+  # @param Len Memory address which will hold length of returned string.
+  # @return String data in MDString.
+  # 
+  # @method get_md_string(v, len)
+  # @param [OpaqueValue] v 
+  # @param [FFI::Pointer(*UInt)] len 
+  # @return [String] 
+  # @scope class
+  attach_function :get_md_string, :LLVMGetMDString, [OpaqueValue, :pointer], :string
+  
+  # Convert a basic block instance to a value type.
   # 
   # @method basic_block_as_value(bb)
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueBasicBlock] bb 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :basic_block_as_value, :LLVMBasicBlockAsValue, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :basic_block_as_value, :LLVMBasicBlockAsValue, [OpaqueBasicBlock], OpaqueValue
+  
+  # Determine whether a LLVMValueRef is itself a basic block.
   # 
   # @method value_is_basic_block(val)
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @param [OpaqueValue] val 
   # @return [Integer] 
   # @scope class
-  attach_function :value_is_basic_block, :LLVMValueIsBasicBlock, [:pointer], :int
-
-  # (Not documented)
+  attach_function :value_is_basic_block, :LLVMValueIsBasicBlock, [OpaqueValue], :int
+  
+  # Convert a LLVMValueRef to a LLVMBasicBlockRef instance.
   # 
   # @method value_as_basic_block(val)
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @param [OpaqueValue] val 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :value_as_basic_block, :LLVMValueAsBasicBlock, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :value_as_basic_block, :LLVMValueAsBasicBlock, [OpaqueValue], OpaqueBasicBlock
+  
+  # Obtain the function to which a basic block belongs.
+  # 
+  # @see llvm::BasicBlock::getParent()
   # 
   # @method get_basic_block_parent(bb)
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueBasicBlock] bb 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_basic_block_parent, :LLVMGetBasicBlockParent, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_basic_block_parent, :LLVMGetBasicBlockParent, [OpaqueBasicBlock], OpaqueValue
+  
+  # Obtain the terminator instruction for a basic block.
+  # 
+  # If the basic block does not have a terminator (it is not well-formed
+  # if it doesn't), then NULL is returned.
+  # 
+  # The returned LLVMValueRef corresponds to a llvm::TerminatorInst.
+  # 
+  # @see llvm::BasicBlock::getTerminator()
   # 
   # @method get_basic_block_terminator(bb)
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueBasicBlock] bb 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_basic_block_terminator, :LLVMGetBasicBlockTerminator, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_basic_block_terminator, :LLVMGetBasicBlockTerminator, [OpaqueBasicBlock], OpaqueValue
+  
+  # Obtain the number of basic blocks in a function.
+  # 
+  # @param Fn Function value to operate on.
   # 
   # @method count_basic_blocks(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @return [Integer] 
   # @scope class
-  attach_function :count_basic_blocks, :LLVMCountBasicBlocks, [:pointer], :uint
-
-  # (Not documented)
+  attach_function :count_basic_blocks, :LLVMCountBasicBlocks, [OpaqueValue], :uint
+  
+  # Obtain all of the basic blocks in a function.
+  # 
+  # This operates on a function value. The BasicBlocks parameter is a
+  # pointer to a pre-allocated array of LLVMBasicBlockRef of at least
+  # LLVMCountBasicBlocks() in length. This array is populated with
+  # LLVMBasicBlockRef instances.
   # 
   # @method get_basic_blocks(fn, basic_blocks)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @param [FFI::Pointer(*BasicBlockRef)] basic_blocks 
   # @return [nil] 
   # @scope class
-  attach_function :get_basic_blocks, :LLVMGetBasicBlocks, [:pointer, :pointer], :void
-
-  # (Not documented)
+  attach_function :get_basic_blocks, :LLVMGetBasicBlocks, [OpaqueValue, :pointer], :void
+  
+  # Obtain the first basic block in a function.
+  # 
+  # The returned basic block can be used as an iterator. You will likely
+  # eventually call into LLVMGetNextBasicBlock() with it.
+  # 
+  # @see llvm::Function::begin()
   # 
   # @method get_first_basic_block(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @param [OpaqueValue] fn 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :get_first_basic_block, :LLVMGetFirstBasicBlock, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_first_basic_block, :LLVMGetFirstBasicBlock, [OpaqueValue], OpaqueBasicBlock
+  
+  # Obtain the last basic block in a function.
+  # 
+  # @see llvm::Function::end()
   # 
   # @method get_last_basic_block(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @param [OpaqueValue] fn 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :get_last_basic_block, :LLVMGetLastBasicBlock, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_last_basic_block, :LLVMGetLastBasicBlock, [OpaqueValue], OpaqueBasicBlock
+  
+  # Advance a basic block iterator.
   # 
   # @method get_next_basic_block(bb)
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @param [OpaqueBasicBlock] bb 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :get_next_basic_block, :LLVMGetNextBasicBlock, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_next_basic_block, :LLVMGetNextBasicBlock, [OpaqueBasicBlock], OpaqueBasicBlock
+  
+  # Go backwards in a basic block iterator.
   # 
   # @method get_previous_basic_block(bb)
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @param [OpaqueBasicBlock] bb 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :get_previous_basic_block, :LLVMGetPreviousBasicBlock, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_previous_basic_block, :LLVMGetPreviousBasicBlock, [OpaqueBasicBlock], OpaqueBasicBlock
+  
+  # Obtain the basic block that corresponds to the entry point of a
+  # function.
+  # 
+  # @see llvm::Function::getEntryBlock()
   # 
   # @method get_entry_basic_block(fn)
-  # @param [FFI::Pointer(ValueRef)] fn 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @param [OpaqueValue] fn 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :get_entry_basic_block, :LLVMGetEntryBasicBlock, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_entry_basic_block, :LLVMGetEntryBasicBlock, [OpaqueValue], OpaqueBasicBlock
+  
+  # Append a basic block to the end of a function.
+  # 
+  # @see llvm::BasicBlock::Create()
   # 
   # @method append_basic_block_in_context(c, fn, name)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueContext] c 
+  # @param [OpaqueValue] fn 
   # @param [String] name 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :append_basic_block_in_context, :LLVMAppendBasicBlockInContext, [:pointer, :pointer, :string], :pointer
-
-  # (Not documented)
+  attach_function :append_basic_block_in_context, :LLVMAppendBasicBlockInContext, [OpaqueContext, OpaqueValue, :string], OpaqueBasicBlock
+  
+  # Append a basic block to the end of a function using the global
+  # context.
   # 
-  # @method insert_basic_block_in_context(c, bb, name)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
-  # @param [String] name 
-  # @return [FFI::Pointer(BasicBlockRef)] 
-  # @scope class
-  attach_function :insert_basic_block_in_context, :LLVMInsertBasicBlockInContext, [:pointer, :pointer, :string], :pointer
-
-  # (Not documented)
+  # @see llvm::BasicBlock::Create()
   # 
   # @method append_basic_block(fn, name)
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @param [OpaqueValue] fn 
   # @param [String] name 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :append_basic_block, :LLVMAppendBasicBlock, [:pointer, :string], :pointer
-
-  # (Not documented)
+  attach_function :append_basic_block, :LLVMAppendBasicBlock, [OpaqueValue, :string], OpaqueBasicBlock
+  
+  # Insert a basic block in a function before another basic block.
+  # 
+  # The function to add to is determined by the function of the
+  # passed basic block.
+  # 
+  # @see llvm::BasicBlock::Create()
+  # 
+  # @method insert_basic_block_in_context(c, bb, name)
+  # @param [OpaqueContext] c 
+  # @param [OpaqueBasicBlock] bb 
+  # @param [String] name 
+  # @return [OpaqueBasicBlock] 
+  # @scope class
+  attach_function :insert_basic_block_in_context, :LLVMInsertBasicBlockInContext, [OpaqueContext, OpaqueBasicBlock, :string], OpaqueBasicBlock
+  
+  # Insert a basic block in a function using the global context.
+  # 
+  # @see llvm::BasicBlock::Create()
   # 
   # @method insert_basic_block(insert_before_bb, name)
-  # @param [FFI::Pointer(BasicBlockRef)] insert_before_bb 
+  # @param [OpaqueBasicBlock] insert_before_bb 
   # @param [String] name 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :insert_basic_block, :LLVMInsertBasicBlock, [:pointer, :string], :pointer
-
-  # (Not documented)
+  attach_function :insert_basic_block, :LLVMInsertBasicBlock, [OpaqueBasicBlock, :string], OpaqueBasicBlock
+  
+  # Remove a basic block from a function and delete it.
+  # 
+  # This deletes the basic block from its containing function and deletes
+  # the basic block itself.
+  # 
+  # @see llvm::BasicBlock::eraseFromParent()
   # 
   # @method delete_basic_block(bb)
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
+  # @param [OpaqueBasicBlock] bb 
   # @return [nil] 
   # @scope class
-  attach_function :delete_basic_block, :LLVMDeleteBasicBlock, [:pointer], :void
-
-  # (Not documented)
+  attach_function :delete_basic_block, :LLVMDeleteBasicBlock, [OpaqueBasicBlock], :void
+  
+  # Remove a basic block from a function.
+  # 
+  # This deletes the basic block from its containing function but keep
+  # the basic block alive.
+  # 
+  # @see llvm::BasicBlock::removeFromParent()
   # 
   # @method remove_basic_block_from_parent(bb)
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
+  # @param [OpaqueBasicBlock] bb 
   # @return [nil] 
   # @scope class
-  attach_function :remove_basic_block_from_parent, :LLVMRemoveBasicBlockFromParent, [:pointer], :void
-
-  # (Not documented)
+  attach_function :remove_basic_block_from_parent, :LLVMRemoveBasicBlockFromParent, [OpaqueBasicBlock], :void
+  
+  # Move a basic block to before another one.
+  # 
+  # @see llvm::BasicBlock::moveBefore()
   # 
   # @method move_basic_block_before(bb, move_pos)
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
-  # @param [FFI::Pointer(BasicBlockRef)] move_pos 
+  # @param [OpaqueBasicBlock] bb 
+  # @param [OpaqueBasicBlock] move_pos 
   # @return [nil] 
   # @scope class
-  attach_function :move_basic_block_before, :LLVMMoveBasicBlockBefore, [:pointer, :pointer], :void
-
-  # (Not documented)
+  attach_function :move_basic_block_before, :LLVMMoveBasicBlockBefore, [OpaqueBasicBlock, OpaqueBasicBlock], :void
+  
+  # Move a basic block to after another one.
+  # 
+  # @see llvm::BasicBlock::moveAfter()
   # 
   # @method move_basic_block_after(bb, move_pos)
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
-  # @param [FFI::Pointer(BasicBlockRef)] move_pos 
+  # @param [OpaqueBasicBlock] bb 
+  # @param [OpaqueBasicBlock] move_pos 
   # @return [nil] 
   # @scope class
-  attach_function :move_basic_block_after, :LLVMMoveBasicBlockAfter, [:pointer, :pointer], :void
-
-  # (Not documented)
+  attach_function :move_basic_block_after, :LLVMMoveBasicBlockAfter, [OpaqueBasicBlock, OpaqueBasicBlock], :void
+  
+  # Obtain the first instruction in a basic block.
+  # 
+  # The returned LLVMValueRef corresponds to a llvm::Instruction
+  # instance.
   # 
   # @method get_first_instruction(bb)
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueBasicBlock] bb 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_first_instruction, :LLVMGetFirstInstruction, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_first_instruction, :LLVMGetFirstInstruction, [OpaqueBasicBlock], OpaqueValue
+  
+  # Obtain the last instruction in a basic block.
+  # 
+  # The returned LLVMValueRef corresponds to a LLVM:Instruction.
   # 
   # @method get_last_instruction(bb)
-  # @param [FFI::Pointer(BasicBlockRef)] bb 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueBasicBlock] bb 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_last_instruction, :LLVMGetLastInstruction, [:pointer], :pointer
-
-  # Operations on instructions
+  attach_function :get_last_instruction, :LLVMGetLastInstruction, [OpaqueBasicBlock], OpaqueValue
+  
+  # Determine whether an instruction has any metadata attached.
   # 
-  # @method get_instruction_parent(inst)
-  # @param [FFI::Pointer(ValueRef)] inst 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @method has_metadata(val)
+  # @param [OpaqueValue] val 
+  # @return [Integer] 
   # @scope class
-  attach_function :get_instruction_parent, :LLVMGetInstructionParent, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :has_metadata, :LLVMHasMetadata, [OpaqueValue], :int
+  
+  # Return metadata associated with an instruction value.
   # 
-  # @method get_next_instruction(inst)
-  # @param [FFI::Pointer(ValueRef)] inst 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @method get_metadata(val, kind_id)
+  # @param [OpaqueValue] val 
+  # @param [Integer] kind_id 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_next_instruction, :LLVMGetNextInstruction, [:pointer], :pointer
-
-  # (Not documented)
+  attach_function :get_metadata, :LLVMGetMetadata, [OpaqueValue, :uint], OpaqueValue
+  
+  # Set metadata associated with an instruction value.
   # 
-  # @method get_previous_instruction(inst)
-  # @param [FFI::Pointer(ValueRef)] inst 
-  # @return [FFI::Pointer(ValueRef)] 
-  # @scope class
-  attach_function :get_previous_instruction, :LLVMGetPreviousInstruction, [:pointer], :pointer
-
-  # (Not documented)
-  # 
-  # @method instruction_erase_from_parent(inst)
-  # @param [FFI::Pointer(ValueRef)] inst 
+  # @method set_metadata(val, kind_id, node)
+  # @param [OpaqueValue] val 
+  # @param [Integer] kind_id 
+  # @param [OpaqueValue] node 
   # @return [nil] 
   # @scope class
-  attach_function :instruction_erase_from_parent, :LLVMInstructionEraseFromParent, [:pointer], :void
-
-  # (Not documented)
+  attach_function :set_metadata, :LLVMSetMetadata, [OpaqueValue, :uint, OpaqueValue], :void
+  
+  # Obtain the basic block to which an instruction belongs.
+  # 
+  # @see llvm::Instruction::getParent()
+  # 
+  # @method get_instruction_parent(inst)
+  # @param [OpaqueValue] inst 
+  # @return [OpaqueBasicBlock] 
+  # @scope class
+  attach_function :get_instruction_parent, :LLVMGetInstructionParent, [OpaqueValue], OpaqueBasicBlock
+  
+  # Obtain the instruction that occurs after the one specified.
+  # 
+  # The next instruction will be from the same basic block.
+  # 
+  # If this is the last instruction in a basic block, NULL will be
+  # returned.
+  # 
+  # @method get_next_instruction(inst)
+  # @param [OpaqueValue] inst 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :get_next_instruction, :LLVMGetNextInstruction, [OpaqueValue], OpaqueValue
+  
+  # Obtain the instruction that occured before this one.
+  # 
+  # If the instruction is the first instruction in a basic block, NULL
+  # will be returned.
+  # 
+  # @method get_previous_instruction(inst)
+  # @param [OpaqueValue] inst 
+  # @return [OpaqueValue] 
+  # @scope class
+  attach_function :get_previous_instruction, :LLVMGetPreviousInstruction, [OpaqueValue], OpaqueValue
+  
+  # Remove and delete an instruction.
+  # 
+  # The instruction specified is removed from its containing building
+  # block and then deleted.
+  # 
+  # @see llvm::Instruction::eraseFromParent()
+  # 
+  # @method instruction_erase_from_parent(inst)
+  # @param [OpaqueValue] inst 
+  # @return [nil] 
+  # @scope class
+  attach_function :instruction_erase_from_parent, :LLVMInstructionEraseFromParent, [OpaqueValue], :void
+  
+  # Obtain the code opcode for an individual instruction.
+  # 
+  # @see llvm::Instruction::getOpCode()
   # 
   # @method get_instruction_opcode(inst)
-  # @param [FFI::Pointer(ValueRef)] inst 
-  # @return [Symbol from opcode_enum] 
+  # @param [OpaqueValue] inst 
+  # @return [Symbol from _enum_opcode_] 
   # @scope class
-  attach_function :get_instruction_opcode, :LLVMGetInstructionOpcode, [:pointer], :opcode
-
-  # (Not documented)
+  attach_function :get_instruction_opcode, :LLVMGetInstructionOpcode, [OpaqueValue], :opcode
+  
+  # Obtain the predicate of an instruction.
+  # 
+  # This is only valid for instructions that correspond to llvm::ICmpInst
+  # or llvm::ConstantExpr whose opcode is llvm::Instruction::ICmp.
+  # 
+  # @see llvm::ICmpInst::getPredicate()
   # 
   # @method get_i_cmp_predicate(inst)
-  # @param [FFI::Pointer(ValueRef)] inst 
-  # @return [Symbol from int_predicate_enum] 
+  # @param [OpaqueValue] inst 
+  # @return [Symbol from _enum_int_predicate_] 
   # @scope class
-  attach_function :get_i_cmp_predicate, :LLVMGetICmpPredicate, [:pointer], :int_predicate
-
-  # Operations on call sites
+  attach_function :get_i_cmp_predicate, :LLVMGetICmpPredicate, [OpaqueValue], :int_predicate
+  
+  # Set the calling convention for a call instruction.
+  # 
+  # This expects an LLVMValueRef that corresponds to a llvm::CallInst or
+  # llvm::InvokeInst.
+  # 
+  # @see llvm::CallInst::setCallingConv()
+  # @see llvm::InvokeInst::setCallingConv()
   # 
   # @method set_instruction_call_conv(instr, cc)
-  # @param [FFI::Pointer(ValueRef)] instr 
+  # @param [OpaqueValue] instr 
   # @param [Integer] cc 
   # @return [nil] 
   # @scope class
-  attach_function :set_instruction_call_conv, :LLVMSetInstructionCallConv, [:pointer, :uint], :void
-
-  # (Not documented)
+  attach_function :set_instruction_call_conv, :LLVMSetInstructionCallConv, [OpaqueValue, :uint], :void
+  
+  # Obtain the calling convention for a call instruction.
+  # 
+  # This is the opposite of LLVMSetInstructionCallConv(). Reads its
+  # usage.
+  # 
+  # @see LLVMSetInstructionCallConv()
   # 
   # @method get_instruction_call_conv(instr)
-  # @param [FFI::Pointer(ValueRef)] instr 
+  # @param [OpaqueValue] instr 
   # @return [Integer] 
   # @scope class
-  attach_function :get_instruction_call_conv, :LLVMGetInstructionCallConv, [:pointer], :uint
-
+  attach_function :get_instruction_call_conv, :LLVMGetInstructionCallConv, [OpaqueValue], :uint
+  
   # (Not documented)
   # 
   # @method add_instr_attribute(instr, index, attribute)
-  # @param [FFI::Pointer(ValueRef)] instr 
+  # @param [OpaqueValue] instr 
   # @param [Integer] index 
-  # @param [Symbol from attribute_enum] attribute 
+  # @param [Symbol from _enum_attribute_] attribute 
   # @return [nil] 
   # @scope class
-  attach_function :add_instr_attribute, :LLVMAddInstrAttribute, [:pointer, :uint, :attribute], :void
-
+  attach_function :add_instr_attribute, :LLVMAddInstrAttribute, [OpaqueValue, :uint, :attribute], :void
+  
   # (Not documented)
   # 
   # @method remove_instr_attribute(instr, index, attribute)
-  # @param [FFI::Pointer(ValueRef)] instr 
+  # @param [OpaqueValue] instr 
   # @param [Integer] index 
-  # @param [Symbol from attribute_enum] attribute 
+  # @param [Symbol from _enum_attribute_] attribute 
   # @return [nil] 
   # @scope class
-  attach_function :remove_instr_attribute, :LLVMRemoveInstrAttribute, [:pointer, :uint, :attribute], :void
-
+  attach_function :remove_instr_attribute, :LLVMRemoveInstrAttribute, [OpaqueValue, :uint, :attribute], :void
+  
   # (Not documented)
   # 
   # @method set_instr_param_alignment(instr, index, align)
-  # @param [FFI::Pointer(ValueRef)] instr 
+  # @param [OpaqueValue] instr 
   # @param [Integer] index 
   # @param [Integer] align 
   # @return [nil] 
   # @scope class
-  attach_function :set_instr_param_alignment, :LLVMSetInstrParamAlignment, [:pointer, :uint, :uint], :void
-
-  # Operations on call instructions (only)
+  attach_function :set_instr_param_alignment, :LLVMSetInstrParamAlignment, [OpaqueValue, :uint, :uint], :void
+  
+  # Obtain whether a call instruction is a tail call.
+  # 
+  # This only works on llvm::CallInst instructions.
+  # 
+  # @see llvm::CallInst::isTailCall()
   # 
   # @method is_tail_call(call_inst)
-  # @param [FFI::Pointer(ValueRef)] call_inst 
+  # @param [OpaqueValue] call_inst 
   # @return [Integer] 
   # @scope class
-  attach_function :is_tail_call, :LLVMIsTailCall, [:pointer], :int
-
-  # (Not documented)
+  attach_function :is_tail_call, :LLVMIsTailCall, [OpaqueValue], :int
+  
+  # Set whether a call instruction is a tail call.
+  # 
+  # This only works on llvm::CallInst instructions.
+  # 
+  # @see llvm::CallInst::setTailCall()
   # 
   # @method set_tail_call(call_inst, is_tail_call)
-  # @param [FFI::Pointer(ValueRef)] call_inst 
+  # @param [OpaqueValue] call_inst 
   # @param [Integer] is_tail_call 
   # @return [nil] 
   # @scope class
-  attach_function :set_tail_call, :LLVMSetTailCall, [:pointer, :int], :void
-
-  # Operations on switch instructions (only)
+  attach_function :set_tail_call, :LLVMSetTailCall, [OpaqueValue, :int], :void
+  
+  # Obtain the default destination basic block of a switch instruction.
+  # 
+  # This only works on llvm::SwitchInst instructions.
+  # 
+  # @see llvm::SwitchInst::getDefaultDest()
   # 
   # @method get_switch_default_dest(switch_instr)
-  # @param [FFI::Pointer(ValueRef)] switch_instr 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @param [OpaqueValue] switch_instr 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :get_switch_default_dest, :LLVMGetSwitchDefaultDest, [:pointer], :pointer
-
-  # Operations on phi nodes
+  attach_function :get_switch_default_dest, :LLVMGetSwitchDefaultDest, [OpaqueValue], OpaqueBasicBlock
+  
+  # Add an incoming value to the end of a PHI list.
   # 
   # @method add_incoming(phi_node, incoming_values, incoming_blocks, count)
-  # @param [FFI::Pointer(ValueRef)] phi_node 
+  # @param [OpaqueValue] phi_node 
   # @param [FFI::Pointer(*ValueRef)] incoming_values 
   # @param [FFI::Pointer(*BasicBlockRef)] incoming_blocks 
   # @param [Integer] count 
   # @return [nil] 
   # @scope class
-  attach_function :add_incoming, :LLVMAddIncoming, [:pointer, :pointer, :pointer, :uint], :void
-
-  # (Not documented)
+  attach_function :add_incoming, :LLVMAddIncoming, [OpaqueValue, :pointer, :pointer, :uint], :void
+  
+  # Obtain the number of incoming basic blocks to a PHI node.
   # 
   # @method count_incoming(phi_node)
-  # @param [FFI::Pointer(ValueRef)] phi_node 
+  # @param [OpaqueValue] phi_node 
   # @return [Integer] 
   # @scope class
-  attach_function :count_incoming, :LLVMCountIncoming, [:pointer], :uint
-
-  # (Not documented)
+  attach_function :count_incoming, :LLVMCountIncoming, [OpaqueValue], :uint
+  
+  # Obtain an incoming value to a PHI node as a LLVMValueRef.
   # 
   # @method get_incoming_value(phi_node, index)
-  # @param [FFI::Pointer(ValueRef)] phi_node 
+  # @param [OpaqueValue] phi_node 
   # @param [Integer] index 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_incoming_value, :LLVMGetIncomingValue, [:pointer, :uint], :pointer
-
-  # (Not documented)
+  attach_function :get_incoming_value, :LLVMGetIncomingValue, [OpaqueValue, :uint], OpaqueValue
+  
+  # Obtain an incoming value to a PHI node as a LLVMBasicBlockRef.
   # 
   # @method get_incoming_block(phi_node, index)
-  # @param [FFI::Pointer(ValueRef)] phi_node 
+  # @param [OpaqueValue] phi_node 
   # @param [Integer] index 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :get_incoming_block, :LLVMGetIncomingBlock, [:pointer, :uint], :pointer
-
-  # An instruction builder represents a point within a basic block, and is the
-  # exclusive means of building instructions using the C interface.
+  attach_function :get_incoming_block, :LLVMGetIncomingBlock, [OpaqueValue, :uint], OpaqueBasicBlock
+  
+  # @defgroup LLVMCCoreInstructionBuilder Instruction Builders
+  # 
+  # An instruction builder represents a point within a basic block and is
+  # the exclusive means of building instructions using the C interface.
+  # 
+  # @{
   # 
   # @method create_builder_in_context(c)
-  # @param [FFI::Pointer(ContextRef)] c 
-  # @return [FFI::Pointer(BuilderRef)] 
+  # @param [OpaqueContext] c 
+  # @return [OpaqueBuilder] 
   # @scope class
-  attach_function :create_builder_in_context, :LLVMCreateBuilderInContext, [:pointer], :pointer
-
+  attach_function :create_builder_in_context, :LLVMCreateBuilderInContext, [OpaqueContext], OpaqueBuilder
+  
   # (Not documented)
   # 
   # @method create_builder()
-  # @return [FFI::Pointer(BuilderRef)] 
+  # @return [OpaqueBuilder] 
   # @scope class
-  attach_function :create_builder, :LLVMCreateBuilder, [], :pointer
-
+  attach_function :create_builder, :LLVMCreateBuilder, [], OpaqueBuilder
+  
   # (Not documented)
   # 
   # @method position_builder(builder, block, instr)
-  # @param [FFI::Pointer(BuilderRef)] builder 
-  # @param [FFI::Pointer(BasicBlockRef)] block 
-  # @param [FFI::Pointer(ValueRef)] instr 
+  # @param [OpaqueBuilder] builder 
+  # @param [OpaqueBasicBlock] block 
+  # @param [OpaqueValue] instr 
   # @return [nil] 
   # @scope class
-  attach_function :position_builder, :LLVMPositionBuilder, [:pointer, :pointer, :pointer], :void
-
+  attach_function :position_builder, :LLVMPositionBuilder, [OpaqueBuilder, OpaqueBasicBlock, OpaqueValue], :void
+  
   # (Not documented)
   # 
   # @method position_builder_before(builder, instr)
-  # @param [FFI::Pointer(BuilderRef)] builder 
-  # @param [FFI::Pointer(ValueRef)] instr 
+  # @param [OpaqueBuilder] builder 
+  # @param [OpaqueValue] instr 
   # @return [nil] 
   # @scope class
-  attach_function :position_builder_before, :LLVMPositionBuilderBefore, [:pointer, :pointer], :void
-
+  attach_function :position_builder_before, :LLVMPositionBuilderBefore, [OpaqueBuilder, OpaqueValue], :void
+  
   # (Not documented)
   # 
   # @method position_builder_at_end(builder, block)
-  # @param [FFI::Pointer(BuilderRef)] builder 
-  # @param [FFI::Pointer(BasicBlockRef)] block 
+  # @param [OpaqueBuilder] builder 
+  # @param [OpaqueBasicBlock] block 
   # @return [nil] 
   # @scope class
-  attach_function :position_builder_at_end, :LLVMPositionBuilderAtEnd, [:pointer, :pointer], :void
-
+  attach_function :position_builder_at_end, :LLVMPositionBuilderAtEnd, [OpaqueBuilder, OpaqueBasicBlock], :void
+  
   # (Not documented)
   # 
   # @method get_insert_block(builder)
-  # @param [FFI::Pointer(BuilderRef)] builder 
-  # @return [FFI::Pointer(BasicBlockRef)] 
+  # @param [OpaqueBuilder] builder 
+  # @return [OpaqueBasicBlock] 
   # @scope class
-  attach_function :get_insert_block, :LLVMGetInsertBlock, [:pointer], :pointer
-
+  attach_function :get_insert_block, :LLVMGetInsertBlock, [OpaqueBuilder], OpaqueBasicBlock
+  
   # (Not documented)
   # 
   # @method clear_insertion_position(builder)
-  # @param [FFI::Pointer(BuilderRef)] builder 
+  # @param [OpaqueBuilder] builder 
   # @return [nil] 
   # @scope class
-  attach_function :clear_insertion_position, :LLVMClearInsertionPosition, [:pointer], :void
-
+  attach_function :clear_insertion_position, :LLVMClearInsertionPosition, [OpaqueBuilder], :void
+  
   # (Not documented)
   # 
   # @method insert_into_builder(builder, instr)
-  # @param [FFI::Pointer(BuilderRef)] builder 
-  # @param [FFI::Pointer(ValueRef)] instr 
+  # @param [OpaqueBuilder] builder 
+  # @param [OpaqueValue] instr 
   # @return [nil] 
   # @scope class
-  attach_function :insert_into_builder, :LLVMInsertIntoBuilder, [:pointer, :pointer], :void
-
+  attach_function :insert_into_builder, :LLVMInsertIntoBuilder, [OpaqueBuilder, OpaqueValue], :void
+  
   # (Not documented)
   # 
   # @method insert_into_builder_with_name(builder, instr, name)
-  # @param [FFI::Pointer(BuilderRef)] builder 
-  # @param [FFI::Pointer(ValueRef)] instr 
+  # @param [OpaqueBuilder] builder 
+  # @param [OpaqueValue] instr 
   # @param [String] name 
   # @return [nil] 
   # @scope class
-  attach_function :insert_into_builder_with_name, :LLVMInsertIntoBuilderWithName, [:pointer, :pointer, :string], :void
-
+  attach_function :insert_into_builder_with_name, :LLVMInsertIntoBuilderWithName, [OpaqueBuilder, OpaqueValue, :string], :void
+  
   # (Not documented)
   # 
   # @method dispose_builder(builder)
-  # @param [FFI::Pointer(BuilderRef)] builder 
+  # @param [OpaqueBuilder] builder 
   # @return [nil] 
   # @scope class
-  attach_function :dispose_builder, :LLVMDisposeBuilder, [:pointer], :void
-
+  attach_function :dispose_builder, :LLVMDisposeBuilder, [OpaqueBuilder], :void
+  
   # Metadata
   # 
   # @method set_current_debug_location(builder, l)
-  # @param [FFI::Pointer(BuilderRef)] builder 
-  # @param [FFI::Pointer(ValueRef)] l 
+  # @param [OpaqueBuilder] builder 
+  # @param [OpaqueValue] l 
   # @return [nil] 
   # @scope class
-  attach_function :set_current_debug_location, :LLVMSetCurrentDebugLocation, [:pointer, :pointer], :void
-
+  attach_function :set_current_debug_location, :LLVMSetCurrentDebugLocation, [OpaqueBuilder, OpaqueValue], :void
+  
   # (Not documented)
   # 
   # @method get_current_debug_location(builder)
-  # @param [FFI::Pointer(BuilderRef)] builder 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueBuilder] builder 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :get_current_debug_location, :LLVMGetCurrentDebugLocation, [:pointer], :pointer
-
+  attach_function :get_current_debug_location, :LLVMGetCurrentDebugLocation, [OpaqueBuilder], OpaqueValue
+  
   # (Not documented)
   # 
   # @method set_inst_debug_location(builder, inst)
-  # @param [FFI::Pointer(BuilderRef)] builder 
-  # @param [FFI::Pointer(ValueRef)] inst 
+  # @param [OpaqueBuilder] builder 
+  # @param [OpaqueValue] inst 
   # @return [nil] 
   # @scope class
-  attach_function :set_inst_debug_location, :LLVMSetInstDebugLocation, [:pointer, :pointer], :void
-
+  attach_function :set_inst_debug_location, :LLVMSetInstDebugLocation, [OpaqueBuilder, OpaqueValue], :void
+  
   # Terminators
   # 
-  # @method build_ret_void(builder_ref)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @method build_ret_void(opaque_builder)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_ret_void, :LLVMBuildRetVoid, [:pointer], :pointer
-
+  attach_function :build_ret_void, :LLVMBuildRetVoid, [OpaqueBuilder], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_ret(builder_ref, v)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] v 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @method build_ret(opaque_builder, v)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] v 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_ret, :LLVMBuildRet, [:pointer, :pointer], :pointer
-
+  attach_function :build_ret, :LLVMBuildRet, [OpaqueBuilder, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_aggregate_ret(builder_ref, ret_vals, n)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
+  # @method build_aggregate_ret(opaque_builder, ret_vals, n)
+  # @param [OpaqueBuilder] opaque_builder 
   # @param [FFI::Pointer(*ValueRef)] ret_vals 
   # @param [Integer] n 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_aggregate_ret, :LLVMBuildAggregateRet, [:pointer, :pointer, :uint], :pointer
-
+  attach_function :build_aggregate_ret, :LLVMBuildAggregateRet, [OpaqueBuilder, :pointer, :uint], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_br(builder_ref, dest)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(BasicBlockRef)] dest 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @method build_br(opaque_builder, dest)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueBasicBlock] dest 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_br, :LLVMBuildBr, [:pointer, :pointer], :pointer
-
+  attach_function :build_br, :LLVMBuildBr, [OpaqueBuilder, OpaqueBasicBlock], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_cond_br(builder_ref, if, then, else)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] if 
-  # @param [FFI::Pointer(BasicBlockRef)] then 
-  # @param [FFI::Pointer(BasicBlockRef)] else 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @method build_cond_br(opaque_builder, if_, then_, else_)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] if_ 
+  # @param [OpaqueBasicBlock] then_ 
+  # @param [OpaqueBasicBlock] else_ 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_cond_br, :LLVMBuildCondBr, [:pointer, :pointer, :pointer, :pointer], :pointer
-
+  attach_function :build_cond_br, :LLVMBuildCondBr, [OpaqueBuilder, OpaqueValue, OpaqueBasicBlock, OpaqueBasicBlock], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_switch(builder_ref, v, else, num_cases)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] v 
-  # @param [FFI::Pointer(BasicBlockRef)] else 
+  # @method build_switch(opaque_builder, v, else_, num_cases)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] v 
+  # @param [OpaqueBasicBlock] else_ 
   # @param [Integer] num_cases 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_switch, :LLVMBuildSwitch, [:pointer, :pointer, :pointer, :uint], :pointer
-
+  attach_function :build_switch, :LLVMBuildSwitch, [OpaqueBuilder, OpaqueValue, OpaqueBasicBlock, :uint], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_indirect_br(b, addr, num_dests)
-  # @param [FFI::Pointer(BuilderRef)] b 
-  # @param [FFI::Pointer(ValueRef)] addr 
+  # @param [OpaqueBuilder] b 
+  # @param [OpaqueValue] addr 
   # @param [Integer] num_dests 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_indirect_br, :LLVMBuildIndirectBr, [:pointer, :pointer, :uint], :pointer
-
+  attach_function :build_indirect_br, :LLVMBuildIndirectBr, [OpaqueBuilder, OpaqueValue, :uint], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_invoke(builder_ref, fn, args, num_args, then, catch, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @method build_invoke(opaque_builder, fn, args, num_args, then_, catch, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] fn 
   # @param [FFI::Pointer(*ValueRef)] args 
   # @param [Integer] num_args 
-  # @param [FFI::Pointer(BasicBlockRef)] then 
-  # @param [FFI::Pointer(BasicBlockRef)] catch 
+  # @param [OpaqueBasicBlock] then_ 
+  # @param [OpaqueBasicBlock] catch 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_invoke, :LLVMBuildInvoke, [:pointer, :pointer, :pointer, :uint, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_invoke, :LLVMBuildInvoke, [OpaqueBuilder, OpaqueValue, :pointer, :uint, OpaqueBasicBlock, OpaqueBasicBlock, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_landing_pad(b, ty, pers_fn, num_clauses, name)
-  # @param [FFI::Pointer(BuilderRef)] b 
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @param [FFI::Pointer(ValueRef)] pers_fn 
+  # @param [OpaqueBuilder] b 
+  # @param [OpaqueType] ty 
+  # @param [OpaqueValue] pers_fn 
   # @param [Integer] num_clauses 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_landing_pad, :LLVMBuildLandingPad, [:pointer, :pointer, :pointer, :uint, :string], :pointer
-
+  attach_function :build_landing_pad, :LLVMBuildLandingPad, [OpaqueBuilder, OpaqueType, OpaqueValue, :uint, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_resume(b, exn)
-  # @param [FFI::Pointer(BuilderRef)] b 
-  # @param [FFI::Pointer(ValueRef)] exn 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @param [OpaqueBuilder] b 
+  # @param [OpaqueValue] exn 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_resume, :LLVMBuildResume, [:pointer, :pointer], :pointer
-
+  attach_function :build_resume, :LLVMBuildResume, [OpaqueBuilder, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_unreachable(builder_ref)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @method build_unreachable(opaque_builder)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_unreachable, :LLVMBuildUnreachable, [:pointer], :pointer
-
+  attach_function :build_unreachable, :LLVMBuildUnreachable, [OpaqueBuilder], OpaqueValue
+  
   # Add a case to the switch instruction
   # 
   # @method add_case(switch, on_val, dest)
-  # @param [FFI::Pointer(ValueRef)] switch 
-  # @param [FFI::Pointer(ValueRef)] on_val 
-  # @param [FFI::Pointer(BasicBlockRef)] dest 
+  # @param [OpaqueValue] switch 
+  # @param [OpaqueValue] on_val 
+  # @param [OpaqueBasicBlock] dest 
   # @return [nil] 
   # @scope class
-  attach_function :add_case, :LLVMAddCase, [:pointer, :pointer, :pointer], :void
-
+  attach_function :add_case, :LLVMAddCase, [OpaqueValue, OpaqueValue, OpaqueBasicBlock], :void
+  
   # Add a destination to the indirectbr instruction
   # 
   # @method add_destination(indirect_br, dest)
-  # @param [FFI::Pointer(ValueRef)] indirect_br 
-  # @param [FFI::Pointer(BasicBlockRef)] dest 
+  # @param [OpaqueValue] indirect_br 
+  # @param [OpaqueBasicBlock] dest 
   # @return [nil] 
   # @scope class
-  attach_function :add_destination, :LLVMAddDestination, [:pointer, :pointer], :void
-
+  attach_function :add_destination, :LLVMAddDestination, [OpaqueValue, OpaqueBasicBlock], :void
+  
   # Add a catch or filter clause to the landingpad instruction
   # 
   # @method add_clause(landing_pad, clause_val)
-  # @param [FFI::Pointer(ValueRef)] landing_pad 
-  # @param [FFI::Pointer(ValueRef)] clause_val 
+  # @param [OpaqueValue] landing_pad 
+  # @param [OpaqueValue] clause_val 
   # @return [nil] 
   # @scope class
-  attach_function :add_clause, :LLVMAddClause, [:pointer, :pointer], :void
-
+  attach_function :add_clause, :LLVMAddClause, [OpaqueValue, OpaqueValue], :void
+  
   # Set the 'cleanup' flag in the landingpad instruction
   # 
   # @method set_cleanup(landing_pad, val)
-  # @param [FFI::Pointer(ValueRef)] landing_pad 
+  # @param [OpaqueValue] landing_pad 
   # @param [Integer] val 
   # @return [nil] 
   # @scope class
-  attach_function :set_cleanup, :LLVMSetCleanup, [:pointer, :int], :void
-
+  attach_function :set_cleanup, :LLVMSetCleanup, [OpaqueValue, :int], :void
+  
   # Arithmetic
   # 
-  # @method build_add(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_add(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_add, :LLVMBuildAdd, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_add, :LLVMBuildAdd, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_nsw_add(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_nsw_add(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_nsw_add, :LLVMBuildNSWAdd, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_nsw_add, :LLVMBuildNSWAdd, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_nuw_add(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_nuw_add(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_nuw_add, :LLVMBuildNUWAdd, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_nuw_add, :LLVMBuildNUWAdd, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_f_add(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_f_add(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_f_add, :LLVMBuildFAdd, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_f_add, :LLVMBuildFAdd, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_sub(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_sub(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_sub, :LLVMBuildSub, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_sub, :LLVMBuildSub, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_nsw_sub(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_nsw_sub(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_nsw_sub, :LLVMBuildNSWSub, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_nsw_sub, :LLVMBuildNSWSub, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_nuw_sub(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_nuw_sub(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_nuw_sub, :LLVMBuildNUWSub, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_nuw_sub, :LLVMBuildNUWSub, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_f_sub(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_f_sub(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_f_sub, :LLVMBuildFSub, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_f_sub, :LLVMBuildFSub, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_mul(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_mul(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_mul, :LLVMBuildMul, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_mul, :LLVMBuildMul, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_nsw_mul(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_nsw_mul(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_nsw_mul, :LLVMBuildNSWMul, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_nsw_mul, :LLVMBuildNSWMul, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_nuw_mul(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_nuw_mul(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_nuw_mul, :LLVMBuildNUWMul, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_nuw_mul, :LLVMBuildNUWMul, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_f_mul(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_f_mul(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_f_mul, :LLVMBuildFMul, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_f_mul, :LLVMBuildFMul, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_u_div(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_u_div(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_u_div, :LLVMBuildUDiv, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_u_div, :LLVMBuildUDiv, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_s_div(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_s_div(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_s_div, :LLVMBuildSDiv, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_s_div, :LLVMBuildSDiv, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_exact_s_div(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_exact_s_div(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_exact_s_div, :LLVMBuildExactSDiv, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_exact_s_div, :LLVMBuildExactSDiv, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_f_div(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_f_div(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_f_div, :LLVMBuildFDiv, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_f_div, :LLVMBuildFDiv, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_u_rem(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_u_rem(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_u_rem, :LLVMBuildURem, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_u_rem, :LLVMBuildURem, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_s_rem(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_s_rem(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_s_rem, :LLVMBuildSRem, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_s_rem, :LLVMBuildSRem, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_f_rem(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_f_rem(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_f_rem, :LLVMBuildFRem, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_f_rem, :LLVMBuildFRem, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_shl(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_shl(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_shl, :LLVMBuildShl, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_shl, :LLVMBuildShl, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_l_shr(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_l_shr(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_l_shr, :LLVMBuildLShr, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_l_shr, :LLVMBuildLShr, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_a_shr(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_a_shr(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_a_shr, :LLVMBuildAShr, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_a_shr, :LLVMBuildAShr, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_and(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_and(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_and, :LLVMBuildAnd, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_and, :LLVMBuildAnd, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_or(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_or(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_or, :LLVMBuildOr, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_or, :LLVMBuildOr, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_xor(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_xor(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_xor, :LLVMBuildXor, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_xor, :LLVMBuildXor, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_bin_op(b, op, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] b 
-  # @param [Symbol from opcode_enum] op 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @param [OpaqueBuilder] b 
+  # @param [Symbol from _enum_opcode_] op 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_bin_op, :LLVMBuildBinOp, [:pointer, :opcode, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_bin_op, :LLVMBuildBinOp, [OpaqueBuilder, :opcode, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_neg(builder_ref, v, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] v 
+  # @method build_neg(opaque_builder, v, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] v 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_neg, :LLVMBuildNeg, [:pointer, :pointer, :string], :pointer
-
+  attach_function :build_neg, :LLVMBuildNeg, [OpaqueBuilder, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_nsw_neg(b, v, name)
-  # @param [FFI::Pointer(BuilderRef)] b 
-  # @param [FFI::Pointer(ValueRef)] v 
+  # @param [OpaqueBuilder] b 
+  # @param [OpaqueValue] v 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_nsw_neg, :LLVMBuildNSWNeg, [:pointer, :pointer, :string], :pointer
-
+  attach_function :build_nsw_neg, :LLVMBuildNSWNeg, [OpaqueBuilder, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_nuw_neg(b, v, name)
-  # @param [FFI::Pointer(BuilderRef)] b 
-  # @param [FFI::Pointer(ValueRef)] v 
+  # @param [OpaqueBuilder] b 
+  # @param [OpaqueValue] v 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_nuw_neg, :LLVMBuildNUWNeg, [:pointer, :pointer, :string], :pointer
-
+  attach_function :build_nuw_neg, :LLVMBuildNUWNeg, [OpaqueBuilder, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_f_neg(builder_ref, v, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] v 
+  # @method build_f_neg(opaque_builder, v, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] v 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_f_neg, :LLVMBuildFNeg, [:pointer, :pointer, :string], :pointer
-
+  attach_function :build_f_neg, :LLVMBuildFNeg, [OpaqueBuilder, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_not(builder_ref, v, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] v 
+  # @method build_not(opaque_builder, v, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] v 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_not, :LLVMBuildNot, [:pointer, :pointer, :string], :pointer
-
+  attach_function :build_not, :LLVMBuildNot, [OpaqueBuilder, OpaqueValue, :string], OpaqueValue
+  
   # Memory
   # 
-  # @method build_malloc(builder_ref, ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(TypeRef)] ty 
+  # @method build_malloc(opaque_builder, ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueType] ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_malloc, :LLVMBuildMalloc, [:pointer, :pointer, :string], :pointer
-
+  attach_function :build_malloc, :LLVMBuildMalloc, [OpaqueBuilder, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_array_malloc(builder_ref, ty, val, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @method build_array_malloc(opaque_builder, ty, val, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueType] ty 
+  # @param [OpaqueValue] val 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_array_malloc, :LLVMBuildArrayMalloc, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_array_malloc, :LLVMBuildArrayMalloc, [OpaqueBuilder, OpaqueType, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_alloca(builder_ref, ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(TypeRef)] ty 
+  # @method build_alloca(opaque_builder, ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueType] ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_alloca, :LLVMBuildAlloca, [:pointer, :pointer, :string], :pointer
-
+  attach_function :build_alloca, :LLVMBuildAlloca, [OpaqueBuilder, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_array_alloca(builder_ref, ty, val, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(TypeRef)] ty 
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @method build_array_alloca(opaque_builder, ty, val, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueType] ty 
+  # @param [OpaqueValue] val 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_array_alloca, :LLVMBuildArrayAlloca, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_array_alloca, :LLVMBuildArrayAlloca, [OpaqueBuilder, OpaqueType, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_free(builder_ref, pointer_val)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] pointer_val 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @method build_free(opaque_builder, pointer_val)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] pointer_val 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_free, :LLVMBuildFree, [:pointer, :pointer], :pointer
-
+  attach_function :build_free, :LLVMBuildFree, [OpaqueBuilder, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_load(builder_ref, pointer_val, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] pointer_val 
+  # @method build_load(opaque_builder, pointer_val, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] pointer_val 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_load, :LLVMBuildLoad, [:pointer, :pointer, :string], :pointer
-
+  attach_function :build_load, :LLVMBuildLoad, [OpaqueBuilder, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_store(builder_ref, val, ptr)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(ValueRef)] ptr 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @method build_store(opaque_builder, val, ptr)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueValue] ptr 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_store, :LLVMBuildStore, [:pointer, :pointer, :pointer], :pointer
-
+  attach_function :build_store, :LLVMBuildStore, [OpaqueBuilder, OpaqueValue, OpaqueValue], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_gep(b, pointer, indices, num_indices, name)
-  # @param [FFI::Pointer(BuilderRef)] b 
-  # @param [FFI::Pointer(ValueRef)] pointer 
+  # @param [OpaqueBuilder] b 
+  # @param [OpaqueValue] pointer 
   # @param [FFI::Pointer(*ValueRef)] indices 
   # @param [Integer] num_indices 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_gep, :LLVMBuildGEP, [:pointer, :pointer, :pointer, :uint, :string], :pointer
-
+  attach_function :build_gep, :LLVMBuildGEP, [OpaqueBuilder, OpaqueValue, :pointer, :uint, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_in_bounds_gep(b, pointer, indices, num_indices, name)
-  # @param [FFI::Pointer(BuilderRef)] b 
-  # @param [FFI::Pointer(ValueRef)] pointer 
+  # @param [OpaqueBuilder] b 
+  # @param [OpaqueValue] pointer 
   # @param [FFI::Pointer(*ValueRef)] indices 
   # @param [Integer] num_indices 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_in_bounds_gep, :LLVMBuildInBoundsGEP, [:pointer, :pointer, :pointer, :uint, :string], :pointer
-
+  attach_function :build_in_bounds_gep, :LLVMBuildInBoundsGEP, [OpaqueBuilder, OpaqueValue, :pointer, :uint, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_struct_gep(b, pointer, idx, name)
-  # @param [FFI::Pointer(BuilderRef)] b 
-  # @param [FFI::Pointer(ValueRef)] pointer 
+  # @param [OpaqueBuilder] b 
+  # @param [OpaqueValue] pointer 
   # @param [Integer] idx 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_struct_gep, :LLVMBuildStructGEP, [:pointer, :pointer, :uint, :string], :pointer
-
+  attach_function :build_struct_gep, :LLVMBuildStructGEP, [OpaqueBuilder, OpaqueValue, :uint, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_global_string(b, str, name)
-  # @param [FFI::Pointer(BuilderRef)] b 
+  # @param [OpaqueBuilder] b 
   # @param [String] str 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_global_string, :LLVMBuildGlobalString, [:pointer, :string, :string], :pointer
-
+  attach_function :build_global_string, :LLVMBuildGlobalString, [OpaqueBuilder, :string, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_global_string_ptr(b, str, name)
-  # @param [FFI::Pointer(BuilderRef)] b 
+  # @param [OpaqueBuilder] b 
   # @param [String] str 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_global_string_ptr, :LLVMBuildGlobalStringPtr, [:pointer, :string, :string], :pointer
-
+  attach_function :build_global_string_ptr, :LLVMBuildGlobalStringPtr, [OpaqueBuilder, :string, :string], OpaqueValue
+  
+  # (Not documented)
+  # 
+  # @method get_volatile(memory_access_inst)
+  # @param [OpaqueValue] memory_access_inst 
+  # @return [Integer] 
+  # @scope class
+  attach_function :get_volatile, :LLVMGetVolatile, [OpaqueValue], :int
+  
+  # (Not documented)
+  # 
+  # @method set_volatile(memory_access_inst, is_volatile)
+  # @param [OpaqueValue] memory_access_inst 
+  # @param [Integer] is_volatile 
+  # @return [nil] 
+  # @scope class
+  attach_function :set_volatile, :LLVMSetVolatile, [OpaqueValue, :int], :void
+  
   # Casts
   # 
-  # @method build_trunc(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_trunc(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_trunc, :LLVMBuildTrunc, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_trunc, :LLVMBuildTrunc, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_z_ext(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_z_ext(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_z_ext, :LLVMBuildZExt, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_z_ext, :LLVMBuildZExt, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_s_ext(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_s_ext(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_s_ext, :LLVMBuildSExt, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_s_ext, :LLVMBuildSExt, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_fp_to_ui(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_fp_to_ui(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_fp_to_ui, :LLVMBuildFPToUI, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_fp_to_ui, :LLVMBuildFPToUI, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_fp_to_si(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_fp_to_si(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_fp_to_si, :LLVMBuildFPToSI, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_fp_to_si, :LLVMBuildFPToSI, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_ui_to_fp(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_ui_to_fp(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_ui_to_fp, :LLVMBuildUIToFP, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_ui_to_fp, :LLVMBuildUIToFP, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_si_to_fp(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_si_to_fp(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_si_to_fp, :LLVMBuildSIToFP, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_si_to_fp, :LLVMBuildSIToFP, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_fp_trunc(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_fp_trunc(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_fp_trunc, :LLVMBuildFPTrunc, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_fp_trunc, :LLVMBuildFPTrunc, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_fp_ext(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_fp_ext(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_fp_ext, :LLVMBuildFPExt, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_fp_ext, :LLVMBuildFPExt, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_ptr_to_int(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_ptr_to_int(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_ptr_to_int, :LLVMBuildPtrToInt, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_ptr_to_int, :LLVMBuildPtrToInt, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_int_to_ptr(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_int_to_ptr(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_int_to_ptr, :LLVMBuildIntToPtr, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_int_to_ptr, :LLVMBuildIntToPtr, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_bit_cast(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_bit_cast(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_bit_cast, :LLVMBuildBitCast, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_bit_cast, :LLVMBuildBitCast, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_z_ext_or_bit_cast(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_z_ext_or_bit_cast(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_z_ext_or_bit_cast, :LLVMBuildZExtOrBitCast, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_z_ext_or_bit_cast, :LLVMBuildZExtOrBitCast, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_s_ext_or_bit_cast(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_s_ext_or_bit_cast(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_s_ext_or_bit_cast, :LLVMBuildSExtOrBitCast, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_s_ext_or_bit_cast, :LLVMBuildSExtOrBitCast, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_trunc_or_bit_cast(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_trunc_or_bit_cast(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_trunc_or_bit_cast, :LLVMBuildTruncOrBitCast, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_trunc_or_bit_cast, :LLVMBuildTruncOrBitCast, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
   # @method build_cast(b, op, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] b 
-  # @param [Symbol from opcode_enum] op 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @param [OpaqueBuilder] b 
+  # @param [Symbol from _enum_opcode_] op 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_cast, :LLVMBuildCast, [:pointer, :opcode, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_cast, :LLVMBuildCast, [OpaqueBuilder, :opcode, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_pointer_cast(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_pointer_cast(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_pointer_cast, :LLVMBuildPointerCast, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_pointer_cast, :LLVMBuildPointerCast, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_int_cast(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_int_cast(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_int_cast, :LLVMBuildIntCast, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_int_cast, :LLVMBuildIntCast, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_fp_cast(builder_ref, val, dest_ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
-  # @param [FFI::Pointer(TypeRef)] dest_ty 
+  # @method build_fp_cast(opaque_builder, val, dest_ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
+  # @param [OpaqueType] dest_ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_fp_cast, :LLVMBuildFPCast, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_fp_cast, :LLVMBuildFPCast, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # Comparisons
   # 
-  # @method build_i_cmp(builder_ref, op, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [Symbol from int_predicate_enum] op 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_i_cmp(opaque_builder, op, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [Symbol from _enum_int_predicate_] op 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_i_cmp, :LLVMBuildICmp, [:pointer, :int_predicate, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_i_cmp, :LLVMBuildICmp, [OpaqueBuilder, :int_predicate, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_f_cmp(builder_ref, op, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [Symbol from real_predicate_enum] op 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_f_cmp(opaque_builder, op, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [Symbol from _enum_real_predicate_] op 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_f_cmp, :LLVMBuildFCmp, [:pointer, :real_predicate, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_f_cmp, :LLVMBuildFCmp, [OpaqueBuilder, :real_predicate, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # Miscellaneous instructions
   # 
-  # @method build_phi(builder_ref, ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(TypeRef)] ty 
+  # @method build_phi(opaque_builder, ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueType] ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_phi, :LLVMBuildPhi, [:pointer, :pointer, :string], :pointer
-
+  attach_function :build_phi, :LLVMBuildPhi, [OpaqueBuilder, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_call(builder_ref, fn, args, num_args, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] fn 
+  # @method build_call(opaque_builder, fn, args, num_args, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] fn 
   # @param [FFI::Pointer(*ValueRef)] args 
   # @param [Integer] num_args 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_call, :LLVMBuildCall, [:pointer, :pointer, :pointer, :uint, :string], :pointer
-
+  attach_function :build_call, :LLVMBuildCall, [OpaqueBuilder, OpaqueValue, :pointer, :uint, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_select(builder_ref, if, then, else, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] if 
-  # @param [FFI::Pointer(ValueRef)] then 
-  # @param [FFI::Pointer(ValueRef)] else 
+  # @method build_select(opaque_builder, if_, then_, else_, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] if_ 
+  # @param [OpaqueValue] then_ 
+  # @param [OpaqueValue] else_ 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_select, :LLVMBuildSelect, [:pointer, :pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_select, :LLVMBuildSelect, [OpaqueBuilder, OpaqueValue, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_va_arg(builder_ref, list, ty, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] list 
-  # @param [FFI::Pointer(TypeRef)] ty 
+  # @method build_va_arg(opaque_builder, list, ty, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] list 
+  # @param [OpaqueType] ty 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_va_arg, :LLVMBuildVAArg, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_va_arg, :LLVMBuildVAArg, [OpaqueBuilder, OpaqueValue, OpaqueType, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_extract_element(builder_ref, vec_val, index, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] vec_val 
-  # @param [FFI::Pointer(ValueRef)] index 
+  # @method build_extract_element(opaque_builder, vec_val, index, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] vec_val 
+  # @param [OpaqueValue] index 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_extract_element, :LLVMBuildExtractElement, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_extract_element, :LLVMBuildExtractElement, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_insert_element(builder_ref, vec_val, elt_val, index, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] vec_val 
-  # @param [FFI::Pointer(ValueRef)] elt_val 
-  # @param [FFI::Pointer(ValueRef)] index 
+  # @method build_insert_element(opaque_builder, vec_val, elt_val, index, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] vec_val 
+  # @param [OpaqueValue] elt_val 
+  # @param [OpaqueValue] index 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_insert_element, :LLVMBuildInsertElement, [:pointer, :pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_insert_element, :LLVMBuildInsertElement, [OpaqueBuilder, OpaqueValue, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_shuffle_vector(builder_ref, v1, v2, mask, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] v1 
-  # @param [FFI::Pointer(ValueRef)] v2 
-  # @param [FFI::Pointer(ValueRef)] mask 
+  # @method build_shuffle_vector(opaque_builder, v1, v2, mask, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] v1 
+  # @param [OpaqueValue] v2 
+  # @param [OpaqueValue] mask 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_shuffle_vector, :LLVMBuildShuffleVector, [:pointer, :pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_shuffle_vector, :LLVMBuildShuffleVector, [OpaqueBuilder, OpaqueValue, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_extract_value(builder_ref, agg_val, index, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] agg_val 
+  # @method build_extract_value(opaque_builder, agg_val, index, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] agg_val 
   # @param [Integer] index 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_extract_value, :LLVMBuildExtractValue, [:pointer, :pointer, :uint, :string], :pointer
-
+  attach_function :build_extract_value, :LLVMBuildExtractValue, [OpaqueBuilder, OpaqueValue, :uint, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_insert_value(builder_ref, agg_val, elt_val, index, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] agg_val 
-  # @param [FFI::Pointer(ValueRef)] elt_val 
+  # @method build_insert_value(opaque_builder, agg_val, elt_val, index, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] agg_val 
+  # @param [OpaqueValue] elt_val 
   # @param [Integer] index 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_insert_value, :LLVMBuildInsertValue, [:pointer, :pointer, :pointer, :uint, :string], :pointer
-
+  attach_function :build_insert_value, :LLVMBuildInsertValue, [OpaqueBuilder, OpaqueValue, OpaqueValue, :uint, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_is_null(builder_ref, val, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @method build_is_null(opaque_builder, val, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_is_null, :LLVMBuildIsNull, [:pointer, :pointer, :string], :pointer
-
+  attach_function :build_is_null, :LLVMBuildIsNull, [OpaqueBuilder, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_is_not_null(builder_ref, val, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] val 
+  # @method build_is_not_null(opaque_builder, val, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] val 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_is_not_null, :LLVMBuildIsNotNull, [:pointer, :pointer, :string], :pointer
-
+  attach_function :build_is_not_null, :LLVMBuildIsNotNull, [OpaqueBuilder, OpaqueValue, :string], OpaqueValue
+  
   # (Not documented)
   # 
-  # @method build_ptr_diff(builder_ref, lhs, rhs, name)
-  # @param [FFI::Pointer(BuilderRef)] builder_ref 
-  # @param [FFI::Pointer(ValueRef)] lhs 
-  # @param [FFI::Pointer(ValueRef)] rhs 
+  # @method build_ptr_diff(opaque_builder, lhs, rhs, name)
+  # @param [OpaqueBuilder] opaque_builder 
+  # @param [OpaqueValue] lhs 
+  # @param [OpaqueValue] rhs 
   # @param [String] name 
-  # @return [FFI::Pointer(ValueRef)] 
+  # @return [OpaqueValue] 
   # @scope class
-  attach_function :build_ptr_diff, :LLVMBuildPtrDiff, [:pointer, :pointer, :pointer, :string], :pointer
-
+  attach_function :build_ptr_diff, :LLVMBuildPtrDiff, [OpaqueBuilder, OpaqueValue, OpaqueValue, :string], OpaqueValue
+  
   # Changes the type of M so it can be passed to FunctionPassManagers and the
   # JIT.  They take ModuleProviders for historical reasons.
   # 
   # @method create_module_provider_for_existing_module(m)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @return [FFI::Pointer(ModuleProviderRef)] 
+  # @param [OpaqueModule] m 
+  # @return [OpaqueModuleProvider] 
   # @scope class
-  attach_function :create_module_provider_for_existing_module, :LLVMCreateModuleProviderForExistingModule, [:pointer], :pointer
-
+  attach_function :create_module_provider_for_existing_module, :LLVMCreateModuleProviderForExistingModule, [OpaqueModule], OpaqueModuleProvider
+  
   # Destroys the module M.
   # 
   # @method dispose_module_provider(m)
-  # @param [FFI::Pointer(ModuleProviderRef)] m 
+  # @param [OpaqueModuleProvider] m 
   # @return [nil] 
   # @scope class
-  attach_function :dispose_module_provider, :LLVMDisposeModuleProvider, [:pointer], :void
-
-  # ===-- Memory buffers ----------------------------------------------------===
+  attach_function :dispose_module_provider, :LLVMDisposeModuleProvider, [OpaqueModuleProvider], :void
+  
+  # @defgroup LLVMCCoreMemoryBuffers Memory Buffers
+  # 
+  # @{
   # 
   # @method create_memory_buffer_with_contents_of_file(path, out_mem_buf, out_message)
   # @param [String] path 
   # @param [FFI::Pointer(*MemoryBufferRef)] out_mem_buf 
-  # @param [FFI::Pointer(**Char_S)] out_message 
+  # @param [FFI::Pointer(**CharS)] out_message 
   # @return [Integer] 
   # @scope class
   attach_function :create_memory_buffer_with_contents_of_file, :LLVMCreateMemoryBufferWithContentsOfFile, [:string, :pointer, :pointer], :int
-
+  
   # (Not documented)
   # 
   # @method create_memory_buffer_with_stdin(out_mem_buf, out_message)
   # @param [FFI::Pointer(*MemoryBufferRef)] out_mem_buf 
-  # @param [FFI::Pointer(**Char_S)] out_message 
+  # @param [FFI::Pointer(**CharS)] out_message 
   # @return [Integer] 
   # @scope class
   attach_function :create_memory_buffer_with_stdin, :LLVMCreateMemoryBufferWithSTDIN, [:pointer, :pointer], :int
-
+  
   # (Not documented)
   # 
   # @method dispose_memory_buffer(mem_buf)
-  # @param [FFI::Pointer(MemoryBufferRef)] mem_buf 
+  # @param [OpaqueMemoryBuffer] mem_buf 
   # @return [nil] 
   # @scope class
-  attach_function :dispose_memory_buffer, :LLVMDisposeMemoryBuffer, [:pointer], :void
-
+  attach_function :dispose_memory_buffer, :LLVMDisposeMemoryBuffer, [OpaqueMemoryBuffer], :void
+  
   # Return the global pass registry, for use with initialization functions.
-  #     See llvm::PassRegistry::getPassRegistry.
+  #     @see llvm::PassRegistry::getPassRegistry
   # 
   # @method get_global_pass_registry()
-  # @return [FFI::Pointer(PassRegistryRef)] 
+  # @return [OpaquePassRegistry] 
   # @scope class
-  attach_function :get_global_pass_registry, :LLVMGetGlobalPassRegistry, [], :pointer
-
+  attach_function :get_global_pass_registry, :LLVMGetGlobalPassRegistry, [], OpaquePassRegistry
+  
   # Constructs a new whole-module pass pipeline. This type of pipeline is
   #     suitable for link-time optimization and whole-module transformations.
-  #     See llvm::PassManager::PassManager.
+  #     @see llvm::PassManager::PassManager
   # 
   # @method create_pass_manager()
-  # @return [FFI::Pointer(PassManagerRef)] 
+  # @return [OpaquePassManager] 
   # @scope class
-  attach_function :create_pass_manager, :LLVMCreatePassManager, [], :pointer
-
+  attach_function :create_pass_manager, :LLVMCreatePassManager, [], OpaquePassManager
+  
   # Constructs a new function-by-function pass pipeline over the module
   #     provider. It does not take ownership of the module provider. This type of
   #     pipeline is suitable for code generation and JIT compilation tasks.
-  #     See llvm::FunctionPassManager::FunctionPassManager.
+  #     @see llvm::FunctionPassManager::FunctionPassManager
   # 
   # @method create_function_pass_manager_for_module(m)
-  # @param [FFI::Pointer(ModuleRef)] m 
-  # @return [FFI::Pointer(PassManagerRef)] 
+  # @param [OpaqueModule] m 
+  # @return [OpaquePassManager] 
   # @scope class
-  attach_function :create_function_pass_manager_for_module, :LLVMCreateFunctionPassManagerForModule, [:pointer], :pointer
-
+  attach_function :create_function_pass_manager_for_module, :LLVMCreateFunctionPassManagerForModule, [OpaqueModule], OpaquePassManager
+  
   # Deprecated: Use LLVMCreateFunctionPassManagerForModule instead.
   # 
   # @method create_function_pass_manager(mp)
-  # @param [FFI::Pointer(ModuleProviderRef)] mp 
-  # @return [FFI::Pointer(PassManagerRef)] 
+  # @param [OpaqueModuleProvider] mp 
+  # @return [OpaquePassManager] 
   # @scope class
-  attach_function :create_function_pass_manager, :LLVMCreateFunctionPassManager, [:pointer], :pointer
-
+  attach_function :create_function_pass_manager, :LLVMCreateFunctionPassManager, [OpaqueModuleProvider], OpaquePassManager
+  
   # Initializes, executes on the provided module, and finalizes all of the
   #     passes scheduled in the pass manager. Returns 1 if any of the passes
-  #     modified the module, 0 otherwise. See llvm::PassManager::run(Module&).
+  #     modified the module, 0 otherwise.
+  #     @see llvm::PassManager::run(Module&)
   # 
   # @method run_pass_manager(pm, m)
-  # @param [FFI::Pointer(PassManagerRef)] pm 
-  # @param [FFI::Pointer(ModuleRef)] m 
+  # @param [OpaquePassManager] pm 
+  # @param [OpaqueModule] m 
   # @return [Integer] 
   # @scope class
-  attach_function :run_pass_manager, :LLVMRunPassManager, [:pointer, :pointer], :int
-
+  attach_function :run_pass_manager, :LLVMRunPassManager, [OpaquePassManager, OpaqueModule], :int
+  
   # Initializes all of the function passes scheduled in the function pass
   #     manager. Returns 1 if any of the passes modified the module, 0 otherwise.
-  #     See llvm::FunctionPassManager::doInitialization.
+  #     @see llvm::FunctionPassManager::doInitialization
   # 
   # @method initialize_function_pass_manager(fpm)
-  # @param [FFI::Pointer(PassManagerRef)] fpm 
+  # @param [OpaquePassManager] fpm 
   # @return [Integer] 
   # @scope class
-  attach_function :initialize_function_pass_manager, :LLVMInitializeFunctionPassManager, [:pointer], :int
-
+  attach_function :initialize_function_pass_manager, :LLVMInitializeFunctionPassManager, [OpaquePassManager], :int
+  
   # Executes all of the function passes scheduled in the function pass manager
   #     on the provided function. Returns 1 if any of the passes modified the
   #     function, false otherwise.
-  #     See llvm::FunctionPassManager::run(Function&).
+  #     @see llvm::FunctionPassManager::run(Function&)
   # 
   # @method run_function_pass_manager(fpm, f)
-  # @param [FFI::Pointer(PassManagerRef)] fpm 
-  # @param [FFI::Pointer(ValueRef)] f 
+  # @param [OpaquePassManager] fpm 
+  # @param [OpaqueValue] f 
   # @return [Integer] 
   # @scope class
-  attach_function :run_function_pass_manager, :LLVMRunFunctionPassManager, [:pointer, :pointer], :int
-
+  attach_function :run_function_pass_manager, :LLVMRunFunctionPassManager, [OpaquePassManager, OpaqueValue], :int
+  
   # Finalizes all of the function passes scheduled in in the function pass
   #     manager. Returns 1 if any of the passes modified the module, 0 otherwise.
-  #     See llvm::FunctionPassManager::doFinalization.
+  #     @see llvm::FunctionPassManager::doFinalization
   # 
   # @method finalize_function_pass_manager(fpm)
-  # @param [FFI::Pointer(PassManagerRef)] fpm 
+  # @param [OpaquePassManager] fpm 
   # @return [Integer] 
   # @scope class
-  attach_function :finalize_function_pass_manager, :LLVMFinalizeFunctionPassManager, [:pointer], :int
-
+  attach_function :finalize_function_pass_manager, :LLVMFinalizeFunctionPassManager, [OpaquePassManager], :int
+  
   # Frees the memory of a pass pipeline. For function pipelines, does not free
   #     the module provider.
-  #     See llvm::PassManagerBase::~PassManagerBase.
+  #     @see llvm::PassManagerBase::~PassManagerBase.
   # 
   # @method dispose_pass_manager(pm)
-  # @param [FFI::Pointer(PassManagerRef)] pm 
+  # @param [OpaquePassManager] pm 
   # @return [nil] 
   # @scope class
-  attach_function :dispose_pass_manager, :LLVMDisposePassManager, [:pointer], :void
-
+  attach_function :dispose_pass_manager, :LLVMDisposePassManager, [OpaquePassManager], :void
+  
 end

--- a/lib/llvm/execution_engine_ffi.rb
+++ b/lib/llvm/execution_engine_ffi.rb
@@ -4,307 +4,309 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib 'LLVM-3.0'
-
+  ffi_lib 'LLVM-3.1'
+  
+  def self.attach_function(name, *_)
+    begin; super; rescue FFI::NotFoundError => e
+      (class << self; self; end).class_eval { define_method(name) { |*_| raise e } }
+    end
+  end
+  
   # (Not documented)
   # 
   # @method link_in_jit()
   # @return [nil] 
   # @scope class
   attach_function :link_in_jit, :LLVMLinkInJIT, [], :void
-
+  
   # (Not documented)
   # 
   # @method link_in_interpreter()
   # @return [nil] 
   # @scope class
   attach_function :link_in_interpreter, :LLVMLinkInInterpreter, [], :void
-
+  
   # (Not documented)
-  # 
-  # = Fields:
-  #
   class OpaqueGenericValue < FFI::Struct
+    layout :dummy, :char
   end
-
+  
   # (Not documented)
-  # 
-  # = Fields:
-  #
   class OpaqueExecutionEngine < FFI::Struct
+    layout :dummy, :char
   end
-
+  
   # ===-- Operations on generic values --------------------------------------===
   # 
   # @method create_generic_value_of_int(ty, n, is_signed)
   # @param [FFI::Pointer(TypeRef)] ty 
   # @param [Integer] n 
   # @param [Integer] is_signed 
-  # @return [FFI::Pointer(GenericValueRef)] 
+  # @return [OpaqueGenericValue] 
   # @scope class
-  attach_function :create_generic_value_of_int, :LLVMCreateGenericValueOfInt, [:pointer, :ulong_long, :int], :pointer
-
+  attach_function :create_generic_value_of_int, :LLVMCreateGenericValueOfInt, [:pointer, :ulong_long, :int], OpaqueGenericValue
+  
   # (Not documented)
   # 
   # @method create_generic_value_of_pointer(p)
   # @param [FFI::Pointer(*Void)] p 
-  # @return [FFI::Pointer(GenericValueRef)] 
+  # @return [OpaqueGenericValue] 
   # @scope class
-  attach_function :create_generic_value_of_pointer, :LLVMCreateGenericValueOfPointer, [:pointer], :pointer
-
+  attach_function :create_generic_value_of_pointer, :LLVMCreateGenericValueOfPointer, [:pointer], OpaqueGenericValue
+  
   # (Not documented)
   # 
   # @method create_generic_value_of_float(ty, n)
   # @param [FFI::Pointer(TypeRef)] ty 
   # @param [Float] n 
-  # @return [FFI::Pointer(GenericValueRef)] 
+  # @return [OpaqueGenericValue] 
   # @scope class
-  attach_function :create_generic_value_of_float, :LLVMCreateGenericValueOfFloat, [:pointer, :double], :pointer
-
+  attach_function :create_generic_value_of_float, :LLVMCreateGenericValueOfFloat, [:pointer, :double], OpaqueGenericValue
+  
   # (Not documented)
   # 
   # @method generic_value_int_width(gen_val_ref)
-  # @param [FFI::Pointer(GenericValueRef)] gen_val_ref 
+  # @param [OpaqueGenericValue] gen_val_ref 
   # @return [Integer] 
   # @scope class
-  attach_function :generic_value_int_width, :LLVMGenericValueIntWidth, [:pointer], :uint
-
+  attach_function :generic_value_int_width, :LLVMGenericValueIntWidth, [OpaqueGenericValue], :uint
+  
   # (Not documented)
   # 
   # @method generic_value_to_int(gen_val, is_signed)
-  # @param [FFI::Pointer(GenericValueRef)] gen_val 
+  # @param [OpaqueGenericValue] gen_val 
   # @param [Integer] is_signed 
   # @return [Integer] 
   # @scope class
-  attach_function :generic_value_to_int, :LLVMGenericValueToInt, [:pointer, :int], :ulong_long
-
+  attach_function :generic_value_to_int, :LLVMGenericValueToInt, [OpaqueGenericValue, :int], :ulong_long
+  
   # (Not documented)
   # 
   # @method generic_value_to_pointer(gen_val)
-  # @param [FFI::Pointer(GenericValueRef)] gen_val 
+  # @param [OpaqueGenericValue] gen_val 
   # @return [FFI::Pointer(*Void)] 
   # @scope class
-  attach_function :generic_value_to_pointer, :LLVMGenericValueToPointer, [:pointer], :pointer
-
+  attach_function :generic_value_to_pointer, :LLVMGenericValueToPointer, [OpaqueGenericValue], :pointer
+  
   # (Not documented)
   # 
   # @method generic_value_to_float(ty_ref, gen_val)
   # @param [FFI::Pointer(TypeRef)] ty_ref 
-  # @param [FFI::Pointer(GenericValueRef)] gen_val 
+  # @param [OpaqueGenericValue] gen_val 
   # @return [Float] 
   # @scope class
-  attach_function :generic_value_to_float, :LLVMGenericValueToFloat, [:pointer, :pointer], :double
-
+  attach_function :generic_value_to_float, :LLVMGenericValueToFloat, [:pointer, OpaqueGenericValue], :double
+  
   # (Not documented)
   # 
   # @method dispose_generic_value(gen_val)
-  # @param [FFI::Pointer(GenericValueRef)] gen_val 
+  # @param [OpaqueGenericValue] gen_val 
   # @return [nil] 
   # @scope class
-  attach_function :dispose_generic_value, :LLVMDisposeGenericValue, [:pointer], :void
-
+  attach_function :dispose_generic_value, :LLVMDisposeGenericValue, [OpaqueGenericValue], :void
+  
   # ===-- Operations on execution engines -----------------------------------===
   # 
   # @method create_execution_engine_for_module(out_ee, m, out_error)
   # @param [FFI::Pointer(*ExecutionEngineRef)] out_ee 
   # @param [FFI::Pointer(ModuleRef)] m 
-  # @param [FFI::Pointer(**Char_S)] out_error 
+  # @param [FFI::Pointer(**CharS)] out_error 
   # @return [Integer] 
   # @scope class
   attach_function :create_execution_engine_for_module, :LLVMCreateExecutionEngineForModule, [:pointer, :pointer, :pointer], :int
-
+  
   # (Not documented)
   # 
   # @method create_interpreter_for_module(out_interp, m, out_error)
   # @param [FFI::Pointer(*ExecutionEngineRef)] out_interp 
   # @param [FFI::Pointer(ModuleRef)] m 
-  # @param [FFI::Pointer(**Char_S)] out_error 
+  # @param [FFI::Pointer(**CharS)] out_error 
   # @return [Integer] 
   # @scope class
   attach_function :create_interpreter_for_module, :LLVMCreateInterpreterForModule, [:pointer, :pointer, :pointer], :int
-
+  
   # (Not documented)
   # 
   # @method create_jit_compiler_for_module(out_jit, m, opt_level, out_error)
   # @param [FFI::Pointer(*ExecutionEngineRef)] out_jit 
   # @param [FFI::Pointer(ModuleRef)] m 
   # @param [Integer] opt_level 
-  # @param [FFI::Pointer(**Char_S)] out_error 
+  # @param [FFI::Pointer(**CharS)] out_error 
   # @return [Integer] 
   # @scope class
   attach_function :create_jit_compiler_for_module, :LLVMCreateJITCompilerForModule, [:pointer, :pointer, :uint, :pointer], :int
-
+  
   # Deprecated: Use LLVMCreateExecutionEngineForModule instead.
   # 
   # @method create_execution_engine(out_ee, mp, out_error)
   # @param [FFI::Pointer(*ExecutionEngineRef)] out_ee 
   # @param [FFI::Pointer(ModuleProviderRef)] mp 
-  # @param [FFI::Pointer(**Char_S)] out_error 
+  # @param [FFI::Pointer(**CharS)] out_error 
   # @return [Integer] 
   # @scope class
   attach_function :create_execution_engine, :LLVMCreateExecutionEngine, [:pointer, :pointer, :pointer], :int
-
+  
   # Deprecated: Use LLVMCreateInterpreterForModule instead.
   # 
   # @method create_interpreter(out_interp, mp, out_error)
   # @param [FFI::Pointer(*ExecutionEngineRef)] out_interp 
   # @param [FFI::Pointer(ModuleProviderRef)] mp 
-  # @param [FFI::Pointer(**Char_S)] out_error 
+  # @param [FFI::Pointer(**CharS)] out_error 
   # @return [Integer] 
   # @scope class
   attach_function :create_interpreter, :LLVMCreateInterpreter, [:pointer, :pointer, :pointer], :int
-
+  
   # Deprecated: Use LLVMCreateJITCompilerForModule instead.
   # 
   # @method create_jit_compiler(out_jit, mp, opt_level, out_error)
   # @param [FFI::Pointer(*ExecutionEngineRef)] out_jit 
   # @param [FFI::Pointer(ModuleProviderRef)] mp 
   # @param [Integer] opt_level 
-  # @param [FFI::Pointer(**Char_S)] out_error 
+  # @param [FFI::Pointer(**CharS)] out_error 
   # @return [Integer] 
   # @scope class
   attach_function :create_jit_compiler, :LLVMCreateJITCompiler, [:pointer, :pointer, :uint, :pointer], :int
-
+  
   # (Not documented)
   # 
   # @method dispose_execution_engine(ee)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @return [nil] 
   # @scope class
-  attach_function :dispose_execution_engine, :LLVMDisposeExecutionEngine, [:pointer], :void
-
+  attach_function :dispose_execution_engine, :LLVMDisposeExecutionEngine, [OpaqueExecutionEngine], :void
+  
   # (Not documented)
   # 
   # @method run_static_constructors(ee)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @return [nil] 
   # @scope class
-  attach_function :run_static_constructors, :LLVMRunStaticConstructors, [:pointer], :void
-
+  attach_function :run_static_constructors, :LLVMRunStaticConstructors, [OpaqueExecutionEngine], :void
+  
   # (Not documented)
   # 
   # @method run_static_destructors(ee)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @return [nil] 
   # @scope class
-  attach_function :run_static_destructors, :LLVMRunStaticDestructors, [:pointer], :void
-
+  attach_function :run_static_destructors, :LLVMRunStaticDestructors, [OpaqueExecutionEngine], :void
+  
   # (Not documented)
   # 
   # @method run_function_as_main(ee, f, arg_c, arg_v, env_p)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @param [FFI::Pointer(ValueRef)] f 
   # @param [Integer] arg_c 
-  # @param [FFI::Pointer(**Char_S)] arg_v 
-  # @param [FFI::Pointer(**Char_S)] env_p 
+  # @param [FFI::Pointer(**CharS)] arg_v 
+  # @param [FFI::Pointer(**CharS)] env_p 
   # @return [Integer] 
   # @scope class
-  attach_function :run_function_as_main, :LLVMRunFunctionAsMain, [:pointer, :pointer, :uint, :pointer, :pointer], :int
-
+  attach_function :run_function_as_main, :LLVMRunFunctionAsMain, [OpaqueExecutionEngine, :pointer, :uint, :pointer, :pointer], :int
+  
   # (Not documented)
   # 
   # @method run_function(ee, f, num_args, args)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @param [FFI::Pointer(ValueRef)] f 
   # @param [Integer] num_args 
   # @param [FFI::Pointer(*GenericValueRef)] args 
-  # @return [FFI::Pointer(GenericValueRef)] 
+  # @return [OpaqueGenericValue] 
   # @scope class
-  attach_function :run_function, :LLVMRunFunction, [:pointer, :pointer, :uint, :pointer], :pointer
-
+  attach_function :run_function, :LLVMRunFunction, [OpaqueExecutionEngine, :pointer, :uint, :pointer], OpaqueGenericValue
+  
   # (Not documented)
   # 
   # @method free_machine_code_for_function(ee, f)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @param [FFI::Pointer(ValueRef)] f 
   # @return [nil] 
   # @scope class
-  attach_function :free_machine_code_for_function, :LLVMFreeMachineCodeForFunction, [:pointer, :pointer], :void
-
+  attach_function :free_machine_code_for_function, :LLVMFreeMachineCodeForFunction, [OpaqueExecutionEngine, :pointer], :void
+  
   # (Not documented)
   # 
   # @method add_module(ee, m)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @param [FFI::Pointer(ModuleRef)] m 
   # @return [nil] 
   # @scope class
-  attach_function :add_module, :LLVMAddModule, [:pointer, :pointer], :void
-
+  attach_function :add_module, :LLVMAddModule, [OpaqueExecutionEngine, :pointer], :void
+  
   # Deprecated: Use LLVMAddModule instead.
   # 
   # @method add_module_provider(ee, mp)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @param [FFI::Pointer(ModuleProviderRef)] mp 
   # @return [nil] 
   # @scope class
-  attach_function :add_module_provider, :LLVMAddModuleProvider, [:pointer, :pointer], :void
-
+  attach_function :add_module_provider, :LLVMAddModuleProvider, [OpaqueExecutionEngine, :pointer], :void
+  
   # (Not documented)
   # 
   # @method remove_module(ee, m, out_mod, out_error)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @param [FFI::Pointer(ModuleRef)] m 
   # @param [FFI::Pointer(*ModuleRef)] out_mod 
-  # @param [FFI::Pointer(**Char_S)] out_error 
+  # @param [FFI::Pointer(**CharS)] out_error 
   # @return [Integer] 
   # @scope class
-  attach_function :remove_module, :LLVMRemoveModule, [:pointer, :pointer, :pointer, :pointer], :int
-
+  attach_function :remove_module, :LLVMRemoveModule, [OpaqueExecutionEngine, :pointer, :pointer, :pointer], :int
+  
   # Deprecated: Use LLVMRemoveModule instead.
   # 
   # @method remove_module_provider(ee, mp, out_mod, out_error)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @param [FFI::Pointer(ModuleProviderRef)] mp 
   # @param [FFI::Pointer(*ModuleRef)] out_mod 
-  # @param [FFI::Pointer(**Char_S)] out_error 
+  # @param [FFI::Pointer(**CharS)] out_error 
   # @return [Integer] 
   # @scope class
-  attach_function :remove_module_provider, :LLVMRemoveModuleProvider, [:pointer, :pointer, :pointer, :pointer], :int
-
+  attach_function :remove_module_provider, :LLVMRemoveModuleProvider, [OpaqueExecutionEngine, :pointer, :pointer, :pointer], :int
+  
   # (Not documented)
   # 
   # @method find_function(ee, name, out_fn)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @param [String] name 
   # @param [FFI::Pointer(*ValueRef)] out_fn 
   # @return [Integer] 
   # @scope class
-  attach_function :find_function, :LLVMFindFunction, [:pointer, :string, :pointer], :int
-
+  attach_function :find_function, :LLVMFindFunction, [OpaqueExecutionEngine, :string, :pointer], :int
+  
   # (Not documented)
   # 
   # @method recompile_and_relink_function(ee, fn)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @param [FFI::Pointer(ValueRef)] fn 
   # @return [FFI::Pointer(*Void)] 
   # @scope class
-  attach_function :recompile_and_relink_function, :LLVMRecompileAndRelinkFunction, [:pointer, :pointer], :pointer
-
+  attach_function :recompile_and_relink_function, :LLVMRecompileAndRelinkFunction, [OpaqueExecutionEngine, :pointer], :pointer
+  
   # (Not documented)
   # 
   # @method get_execution_engine_target_data(ee)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @return [FFI::Pointer(TargetDataRef)] 
   # @scope class
-  attach_function :get_execution_engine_target_data, :LLVMGetExecutionEngineTargetData, [:pointer], :pointer
-
+  attach_function :get_execution_engine_target_data, :LLVMGetExecutionEngineTargetData, [OpaqueExecutionEngine], :pointer
+  
   # (Not documented)
   # 
   # @method add_global_mapping(ee, global, addr)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @param [FFI::Pointer(ValueRef)] global 
   # @param [FFI::Pointer(*Void)] addr 
   # @return [nil] 
   # @scope class
-  attach_function :add_global_mapping, :LLVMAddGlobalMapping, [:pointer, :pointer, :pointer], :void
-
+  attach_function :add_global_mapping, :LLVMAddGlobalMapping, [OpaqueExecutionEngine, :pointer, :pointer], :void
+  
   # (Not documented)
   # 
   # @method get_pointer_to_global(ee, global)
-  # @param [FFI::Pointer(ExecutionEngineRef)] ee 
+  # @param [OpaqueExecutionEngine] ee 
   # @param [FFI::Pointer(ValueRef)] global 
   # @return [FFI::Pointer(*Void)] 
   # @scope class
-  attach_function :get_pointer_to_global, :LLVMGetPointerToGlobal, [:pointer, :pointer], :pointer
-
+  attach_function :get_pointer_to_global, :LLVMGetPointerToGlobal, [OpaqueExecutionEngine, :pointer], :pointer
+  
 end

--- a/lib/llvm/support.rb
+++ b/lib/llvm/support.rb
@@ -7,7 +7,7 @@ module LLVM
                       File.join(
                         File.dirname(__FILE__),
                         '../',
-                        FFI.map_library_name('RubyLLVMSupport-3.0.0')))
+                        FFI.map_library_name('RubyLLVMSupport-3.1.0')))
       ffi_lib [support_lib]
       attach_function :load_library_permanently, :LLVMLoadLibraryPermanently, [:string], :int
     end

--- a/lib/llvm/transforms/ipo_ffi.rb
+++ b/lib/llvm/transforms/ipo_ffi.rb
@@ -4,8 +4,14 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib 'LLVM-3.0'
-
+  ffi_lib 'LLVM-3.1'
+  
+  def self.attach_function(name, *_)
+    begin; super; rescue FFI::NotFoundError => e
+      (class << self; self; end).class_eval { define_method(name) { |*_| raise e } }
+    end
+  end
+  
   # (Not documented)
   # 
   # @method add_argument_promotion_pass(pm)
@@ -13,7 +19,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_argument_promotion_pass, :LLVMAddArgumentPromotionPass, [:pointer], :void
-
+  
   # See llvm::createConstantMergePass function.
   # 
   # @method add_constant_merge_pass(pm)
@@ -21,7 +27,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_constant_merge_pass, :LLVMAddConstantMergePass, [:pointer], :void
-
+  
   # See llvm::createDeadArgEliminationPass function.
   # 
   # @method add_dead_arg_elimination_pass(pm)
@@ -29,7 +35,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_dead_arg_elimination_pass, :LLVMAddDeadArgEliminationPass, [:pointer], :void
-
+  
   # See llvm::createFunctionAttrsPass function.
   # 
   # @method add_function_attrs_pass(pm)
@@ -37,7 +43,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_function_attrs_pass, :LLVMAddFunctionAttrsPass, [:pointer], :void
-
+  
   # See llvm::createFunctionInliningPass function.
   # 
   # @method add_function_inlining_pass(pm)
@@ -45,7 +51,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_function_inlining_pass, :LLVMAddFunctionInliningPass, [:pointer], :void
-
+  
   # See llvm::createAlwaysInlinerPass function.
   # 
   # @method add_always_inliner_pass(pm)
@@ -53,7 +59,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_always_inliner_pass, :LLVMAddAlwaysInlinerPass, [:pointer], :void
-
+  
   # See llvm::createGlobalDCEPass function.
   # 
   # @method add_global_dce_pass(pm)
@@ -61,7 +67,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_global_dce_pass, :LLVMAddGlobalDCEPass, [:pointer], :void
-
+  
   # See llvm::createGlobalOptimizerPass function.
   # 
   # @method add_global_optimizer_pass(pm)
@@ -69,7 +75,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_global_optimizer_pass, :LLVMAddGlobalOptimizerPass, [:pointer], :void
-
+  
   # See llvm::createIPConstantPropagationPass function.
   # 
   # @method add_ip_constant_propagation_pass(pm)
@@ -77,7 +83,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_ip_constant_propagation_pass, :LLVMAddIPConstantPropagationPass, [:pointer], :void
-
+  
   # See llvm::createPruneEHPass function.
   # 
   # @method add_prune_eh_pass(pm)
@@ -85,7 +91,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_prune_eh_pass, :LLVMAddPruneEHPass, [:pointer], :void
-
+  
   # See llvm::createIPSCCPPass function.
   # 
   # @method add_ipsccp_pass(pm)
@@ -93,7 +99,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_ipsccp_pass, :LLVMAddIPSCCPPass, [:pointer], :void
-
+  
   # See llvm::createInternalizePass function.
   # 
   # @method add_internalize_pass(pass_manager_ref, all_but_main)
@@ -102,7 +108,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_internalize_pass, :LLVMAddInternalizePass, [:pointer, :uint], :void
-
+  
   # See llvm::createStripDeadPrototypesPass function.
   # 
   # @method add_strip_dead_prototypes_pass(pm)
@@ -110,7 +116,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_strip_dead_prototypes_pass, :LLVMAddStripDeadPrototypesPass, [:pointer], :void
-
+  
   # See llvm::createStripSymbolsPass function.
   # 
   # @method add_strip_symbols_pass(pm)
@@ -118,5 +124,5 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_strip_symbols_pass, :LLVMAddStripSymbolsPass, [:pointer], :void
-
+  
 end

--- a/lib/llvm/transforms/scalar_ffi.rb
+++ b/lib/llvm/transforms/scalar_ffi.rb
@@ -4,8 +4,14 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib 'LLVM-3.0'
-
+  ffi_lib 'LLVM-3.1'
+  
+  def self.attach_function(name, *_)
+    begin; super; rescue FFI::NotFoundError => e
+      (class << self; self; end).class_eval { define_method(name) { |*_| raise e } }
+    end
+  end
+  
   # (Not documented)
   # 
   # @method add_aggressive_dce_pass(pm)
@@ -13,7 +19,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_aggressive_dce_pass, :LLVMAddAggressiveDCEPass, [:pointer], :void
-
+  
   # See llvm::createCFGSimplificationPass function.
   # 
   # @method add_cfg_simplification_pass(pm)
@@ -21,7 +27,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_cfg_simplification_pass, :LLVMAddCFGSimplificationPass, [:pointer], :void
-
+  
   # See llvm::createDeadStoreEliminationPass function.
   # 
   # @method add_dead_store_elimination_pass(pm)
@@ -29,7 +35,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_dead_store_elimination_pass, :LLVMAddDeadStoreEliminationPass, [:pointer], :void
-
+  
   # See llvm::createGVNPass function.
   # 
   # @method add_gvn_pass(pm)
@@ -37,7 +43,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_gvn_pass, :LLVMAddGVNPass, [:pointer], :void
-
+  
   # See llvm::createIndVarSimplifyPass function.
   # 
   # @method add_ind_var_simplify_pass(pm)
@@ -45,7 +51,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_ind_var_simplify_pass, :LLVMAddIndVarSimplifyPass, [:pointer], :void
-
+  
   # See llvm::createInstructionCombiningPass function.
   # 
   # @method add_instruction_combining_pass(pm)
@@ -53,7 +59,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_instruction_combining_pass, :LLVMAddInstructionCombiningPass, [:pointer], :void
-
+  
   # See llvm::createJumpThreadingPass function.
   # 
   # @method add_jump_threading_pass(pm)
@@ -61,7 +67,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_jump_threading_pass, :LLVMAddJumpThreadingPass, [:pointer], :void
-
+  
   # See llvm::createLICMPass function.
   # 
   # @method add_licm_pass(pm)
@@ -69,7 +75,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_licm_pass, :LLVMAddLICMPass, [:pointer], :void
-
+  
   # See llvm::createLoopDeletionPass function.
   # 
   # @method add_loop_deletion_pass(pm)
@@ -77,7 +83,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_loop_deletion_pass, :LLVMAddLoopDeletionPass, [:pointer], :void
-
+  
   # See llvm::createLoopIdiomPass function
   # 
   # @method add_loop_idiom_pass(pm)
@@ -85,7 +91,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_loop_idiom_pass, :LLVMAddLoopIdiomPass, [:pointer], :void
-
+  
   # See llvm::createLoopRotatePass function.
   # 
   # @method add_loop_rotate_pass(pm)
@@ -93,7 +99,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_loop_rotate_pass, :LLVMAddLoopRotatePass, [:pointer], :void
-
+  
   # See llvm::createLoopUnrollPass function.
   # 
   # @method add_loop_unroll_pass(pm)
@@ -101,7 +107,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_loop_unroll_pass, :LLVMAddLoopUnrollPass, [:pointer], :void
-
+  
   # See llvm::createLoopUnswitchPass function.
   # 
   # @method add_loop_unswitch_pass(pm)
@@ -109,7 +115,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_loop_unswitch_pass, :LLVMAddLoopUnswitchPass, [:pointer], :void
-
+  
   # See llvm::createMemCpyOptPass function.
   # 
   # @method add_mem_cpy_opt_pass(pm)
@@ -117,7 +123,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_mem_cpy_opt_pass, :LLVMAddMemCpyOptPass, [:pointer], :void
-
+  
   # See llvm::createPromoteMemoryToRegisterPass function.
   # 
   # @method add_promote_memory_to_register_pass(pm)
@@ -125,7 +131,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_promote_memory_to_register_pass, :LLVMAddPromoteMemoryToRegisterPass, [:pointer], :void
-
+  
   # See llvm::createReassociatePass function.
   # 
   # @method add_reassociate_pass(pm)
@@ -133,7 +139,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_reassociate_pass, :LLVMAddReassociatePass, [:pointer], :void
-
+  
   # See llvm::createSCCPPass function.
   # 
   # @method add_sccp_pass(pm)
@@ -141,7 +147,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_sccp_pass, :LLVMAddSCCPPass, [:pointer], :void
-
+  
   # See llvm::createScalarReplAggregatesPass function.
   # 
   # @method add_scalar_repl_aggregates_pass(pm)
@@ -149,7 +155,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_scalar_repl_aggregates_pass, :LLVMAddScalarReplAggregatesPass, [:pointer], :void
-
+  
   # See llvm::createScalarReplAggregatesPass function.
   # 
   # @method add_scalar_repl_aggregates_pass_ssa(pm)
@@ -157,7 +163,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_scalar_repl_aggregates_pass_ssa, :LLVMAddScalarReplAggregatesPassSSA, [:pointer], :void
-
+  
   # See llvm::createScalarReplAggregatesPass function.
   # 
   # @method add_scalar_repl_aggregates_pass_with_threshold(pm, threshold)
@@ -166,7 +172,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_scalar_repl_aggregates_pass_with_threshold, :LLVMAddScalarReplAggregatesPassWithThreshold, [:pointer, :int], :void
-
+  
   # See llvm::createSimplifyLibCallsPass function.
   # 
   # @method add_simplify_lib_calls_pass(pm)
@@ -174,7 +180,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_simplify_lib_calls_pass, :LLVMAddSimplifyLibCallsPass, [:pointer], :void
-
+  
   # See llvm::createTailCallEliminationPass function.
   # 
   # @method add_tail_call_elimination_pass(pm)
@@ -182,7 +188,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_tail_call_elimination_pass, :LLVMAddTailCallEliminationPass, [:pointer], :void
-
+  
   # See llvm::createConstantPropagationPass function.
   # 
   # @method add_constant_propagation_pass(pm)
@@ -190,7 +196,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_constant_propagation_pass, :LLVMAddConstantPropagationPass, [:pointer], :void
-
+  
   # See llvm::demotePromoteMemoryToRegisterPass function.
   # 
   # @method add_demote_memory_to_register_pass(pm)
@@ -198,7 +204,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_demote_memory_to_register_pass, :LLVMAddDemoteMemoryToRegisterPass, [:pointer], :void
-
+  
   # See llvm::createVerifierPass function.
   # 
   # @method add_verifier_pass(pm)
@@ -206,7 +212,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_verifier_pass, :LLVMAddVerifierPass, [:pointer], :void
-
+  
   # See llvm::createCorrelatedValuePropagationPass function
   # 
   # @method add_correlated_value_propagation_pass(pm)
@@ -214,7 +220,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_correlated_value_propagation_pass, :LLVMAddCorrelatedValuePropagationPass, [:pointer], :void
-
+  
   # See llvm::createEarlyCSEPass function
   # 
   # @method add_early_cse_pass(pm)
@@ -222,7 +228,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_early_cse_pass, :LLVMAddEarlyCSEPass, [:pointer], :void
-
+  
   # See llvm::createLowerExpectIntrinsicPass function
   # 
   # @method add_lower_expect_intrinsic_pass(pm)
@@ -230,7 +236,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_lower_expect_intrinsic_pass, :LLVMAddLowerExpectIntrinsicPass, [:pointer], :void
-
+  
   # See llvm::createTypeBasedAliasAnalysisPass function
   # 
   # @method add_type_based_alias_analysis_pass(pm)
@@ -238,7 +244,7 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_type_based_alias_analysis_pass, :LLVMAddTypeBasedAliasAnalysisPass, [:pointer], :void
-
+  
   # See llvm::createBasicAliasAnalysisPass function
   # 
   # @method add_basic_alias_analysis_pass(pm)
@@ -246,5 +252,5 @@ module LLVM::C
   # @return [nil] 
   # @scope class
   attach_function :add_basic_alias_analysis_pass, :LLVMAddBasicAliasAnalysisPass, [:pointer], :void
-
+  
 end

--- a/lib/llvm/version.rb
+++ b/lib/llvm/version.rb
@@ -1,4 +1,4 @@
 module LLVM
-  LLVM_VERSION = "3.0"
-  RUBY_LLVM_VERSION = "3.0.0"
+  LLVM_VERSION = "3.1"
+  RUBY_LLVM_VERSION = "3.1.0"
 end

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -9,13 +9,13 @@ class ArrayTestCase < Test::Unit::TestCase
   def test_constant_array_from_size
     array = LLVM::ConstantArray.const(LLVM::Int, 2) { |i| LLVM::Int(i) }
     assert_instance_of LLVM::ConstantArray, array
-    assert_equal 2, array.operands.size
+    assert_equal 2, array.size
   end
 
   def test_constant_array_from_array
     array = LLVM::ConstantArray.const(LLVM::Int, [LLVM::Int(0), LLVM::Int(1)])
     assert_instance_of LLVM::ConstantArray, array
-    assert_equal 2, array.operands.size
+    assert_equal 2, array.size
   end
 
   def test_array_values

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -15,13 +15,13 @@ class VectorTestCase < Test::Unit::TestCase
   def test_constant_vector_from_size
     vector = LLVM::ConstantVector.const(2) { |i| LLVM::Int(i) }
     assert_instance_of LLVM::ConstantVector, vector
-    assert_equal 2, vector.operands.size
+    assert_equal 2, vector.size
   end
 
   def test_constant_vector_from_array
     vector = LLVM::ConstantVector.const([LLVM::Int(0), LLVM::Int(1)])
     assert_instance_of LLVM::ConstantVector, vector
-    assert_equal 2, vector.operands.size
+    assert_equal 2, vector.size
   end
 
   def test_vector_elements


### PR DESCRIPTION
I just upgraded the gem to link against LLVM 3.1.
All the tests are passing. The only non trivial change I had to make was in the ConstantArray and ConstantVector classes. The tests were looking for the "operands.size" but these return zero in 3.1. Instead, I added a "size" property that calls LLVMGetArrayLength and LLVMGetVectorSize respectively.
