### PR TITLE
Add support for llvm::GlobalValue#hasUnnamedAddr, llvm::GlobalValue#setUnnamedAddr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.dylib
+*.dSYM
 *.la
 *.lo
 *.o

--- a/ext/ruby-llvm-support/support.cpp
+++ b/ext/ruby-llvm-support/support.cpp
@@ -2,12 +2,23 @@
  * Extended bindings for LLVM.
  */
 
-#include <llvm/ADT/StringRef.h>
+#include <llvm-c/Core.h>
+#include <llvm/GlobalValue.h>
 #include <llvm/Support/DynamicLibrary.h>
 
 extern "C" {
+  using namespace llvm;
+
   int LLVMLoadLibraryPermanently(const char* filename) {
     return llvm::sys::DynamicLibrary::LoadLibraryPermanently(filename);
+  }
+
+  LLVMBool LLVMHasUnnamedAddr(LLVMValueRef global) {
+    return unwrap<GlobalValue>(global)->hasUnnamedAddr();
+  }
+
+  void LLVMSetUnnamedAddr(LLVMValueRef global, LLVMBool val) {
+    unwrap<GlobalValue>(global)->setUnnamedAddr(val != 0);
   }
 }
 

--- a/lib/llvm/core.rb
+++ b/lib/llvm/core.rb
@@ -1,5 +1,6 @@
 require 'llvm'
 require 'llvm/core_ffi'
+require 'llvm/support'
 
 module LLVM
   # @private

--- a/lib/llvm/core/module.rb
+++ b/lib/llvm/core/module.rb
@@ -79,7 +79,9 @@ module LLVM
       
       # Adds a GlobalVariable with the given type and name to the collection (symbol or string).
       def add(ty, name)
-        GlobalVariable.from_ptr(C.add_global(@module, LLVM::Type(ty), name.to_s))
+        GlobalVariable.from_ptr(C.add_global(@module, LLVM::Type(ty), name.to_s)).tap do |gvar|
+          yield gvar if block_given?
+        end
       end
       
       # Returns the GlobalVariable with the given name (symbol or string).

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -594,6 +594,14 @@ module LLVM
     def global_constant=(flag)
       C.set_global_constant(self, flag)
     end
+
+    def unnamed_addr?
+      Support::C.has_unnamed_addr(self) != 0
+    end
+
+    def unnamed_addr=(flag)
+      Support::C.set_unnamed_addr(self, flag ? 1 : 0)
+    end
   end
 
   class Function < GlobalValue

--- a/lib/llvm/support.rb
+++ b/lib/llvm/support.rb
@@ -1,8 +1,13 @@
 module LLVM
+
   module Support
     # @private
     module C
       extend FFI::Library
+
+      require 'llvm/core_ffi'
+      OpaqueValue = LLVM::C::OpaqueValue
+
       support_lib = File.expand_path(
                       File.join(
                         File.dirname(__FILE__),
@@ -10,6 +15,8 @@ module LLVM
                         FFI.map_library_name('RubyLLVMSupport-3.1.0')))
       ffi_lib [support_lib]
       attach_function :load_library_permanently, :LLVMLoadLibraryPermanently, [:string], :int
+      attach_function :has_unnamed_addr, :LLVMHasUnnamedAddr, [OpaqueValue], :int
+      attach_function :set_unnamed_addr, :LLVMSetUnnamedAddr, [OpaqueValue, :int], :void
     end
   end
 

--- a/samples/hello.rb
+++ b/samples/hello.rb
@@ -8,11 +8,11 @@ HELLO_STRING = "Hello, World!"
 mod = LLVM::Module.new('hello')
 
 # Declare the string constant as a global constant.
-hello = mod.globals.add(LLVM.Array(LLVM::Int8, HELLO_STRING.size + 1), '.str').tap do |var|
+hello = mod.globals.add(LLVM.Array(LLVM::Int8, HELLO_STRING.size + 1), '.str') do |var|
   var.linkage = :private
   var.global_constant = 1
+  var.unnamed_addr = true
   var.initializer = LLVM::ConstantArray.string(HELLO_STRING)
-  # TODO LLVM C bindings doesn't support GlobalVariable::setUnnamedAddr(bool)
 end
 
 # External declaration of the `puts` function

--- a/samples/hello.rb
+++ b/samples/hello.rb
@@ -1,0 +1,45 @@
+# LLVM 'Hello, World!' example from
+# http://llvm.org/docs/LangRef.html#module-structure
+require 'llvm/core'
+require 'llvm/execution_engine'
+
+HELLO_STRING = "Hello, World!"
+
+mod = LLVM::Module.new('hello')
+
+# Declare the string constant as a global constant.
+hello = mod.globals.add(LLVM.Array(LLVM::Int8, HELLO_STRING.size + 1), '.str').tap do |var|
+  var.linkage = :private
+  var.global_constant = 1
+  var.initializer = LLVM::ConstantArray.string(HELLO_STRING)
+  # TODO LLVM C bindings doesn't support GlobalVariable::setUnnamedAddr(bool)
+end
+
+# External declaration of the `puts` function
+cputs = mod.functions.add('puts', [LLVM.Pointer(LLVM::Int8)], LLVM::Int32) do |function, string|
+  function.add_attribute :no_unwind_attribute
+  string.add_attribute :no_capture_attribute
+end
+
+# Definition of main function
+main = mod.functions.add('main', [], LLVM::Int32) do |function|
+  function.basic_blocks.append.build do |b|
+    zero = LLVM.Int(0)
+
+    # Convert [13 x i8]* to i8  *...
+    cast210 = b.gep hello, [zero, zero], 'cast210'
+    # Call puts function to write out the string to stdout.
+    b.call cputs, cast210
+    b.ret zero
+  end
+end
+
+mod.dump
+#mod.dispose
+puts "------------------------------"
+
+LLVM.init_x86
+
+engine = LLVM::JITCompiler.new(mod)
+engine.run_function(main)
+engine.dispose

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -18,15 +18,21 @@ class ModuleTestCase < Test::Unit::TestCase
     end
   end
 
-  def test_globals_add
-    gvar = nil
+  def test_global_variable
+    yielded = false
+
     define_module('test_globals_add') do |mod|
       mod.globals.add(LLVM::Int32, 'i') do |var|
-        gvar = var
+        yielded = true
+        assert_not_nil var
+        assert var.kind_of?(LLVM::GlobalVariable)
+
+        assert !var.unnamed_addr?
+        var.unnamed_addr = true
+        assert var.unnamed_addr?
       end
     end
 
-    assert_not_nil gvar
-    assert gvar.kind_of?(LLVM::GlobalVariable)
+    assert yielded, 'LLVM::Module::GlobalCollection#add takes block'
   end
 end

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -18,4 +18,15 @@ class ModuleTestCase < Test::Unit::TestCase
     end
   end
 
+  def test_globals_add
+    gvar = nil
+    define_module('test_globals_add') do |mod|
+      mod.globals.add(LLVM::Int32, 'i') do |var|
+        gvar = var
+      end
+    end
+
+    assert_not_nil gvar
+    assert gvar.kind_of?(LLVM::GlobalVariable)
+  end
 end


### PR DESCRIPTION
- Add .dSYM in .gitignore
- support.cpp: LLVMHasUnnamedAddr(v), LLVMSetUnnamedAddr(v, b)
- Ruby: LLVM::GlobalValue unnamed_addr?, unnamed_addr=
- 'Hello, World!' example in sample/
